### PR TITLE
adds poison_options config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Elastix.Document.delete(elastic_url, index_name, doc_type, product.id)
 
 ```
 
+## Configuration
+You can pass options to the JSON decoder ([poison](https://github.com/devinus/poison)) by setting the `poison_options`
+key in your `config/config.exs`:
+
+```elixir
+config :elastix, :poison_options, [keys: :atoms]
+```
+
+The above for example will lead to the HTTPoison responses being parsed into maps with atom keys instead of string keys.
+
 ## License
 
 Copyright © 2015 El Werbitzky <werbitzky@gmail.com>

--- a/lib/elastix/http.ex
+++ b/lib/elastix/http.ex
@@ -24,9 +24,13 @@ defmodule Elastix.HTTP do
 
   @doc false
   def process_response_body(body) do
-    case body |> to_string |> Poison.decode do
+    case body |> to_string |> Poison.decode(poison_options) do
       {:error, _} -> body
       {:ok, decoded} -> decoded
     end
+  end
+
+  defp poison_options do
+    Application.get_env(:elastix, :poison_options, [])
   end
 end

--- a/test/elastix/http_test.exs
+++ b/test/elastix/http_test.exs
@@ -28,4 +28,21 @@ defmodule Elastix.HTTPTest do
     {_, response} = HTTP.delete(@test_url, [])
     assert response.status_code == 400
   end
+
+  test "process_response_body should parse the json body into a map" do
+    body = "{\"some\":\"json\"}"
+    assert HTTP.process_response_body(body) == %{"some" => "json"}
+  end
+
+  test "process_response_body returns the raw body if it cannot be parsed as json" do
+    body = "no_json"
+    assert HTTP.process_response_body(body) == body
+  end
+
+  test "process_response_body parsed the body into an atom key map if configured" do
+    body = "{\"some\":\"json\"}"
+    Application.put_env(:elastix, :poison_options, [keys: :atoms])
+    assert HTTP.process_response_body(body) == %{some: "json"}
+    Application.delete_env(:elastix, :poison_options)
+  end
 end


### PR DESCRIPTION
This adds a `poison_options` configuration, which allows specifying options for poison to use when decoding responses.

I'm using this to get back maps with atoms as keys. I know this is most of the time a bad idea, but in this case I control all the i store in elasticsearch, so there's no security risk attached. I could imagine this is the case with a lot of elasticsearch use cases.