### PR TITLE
Use PUTs for index creation

### DIFF
--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -6,7 +6,7 @@ defmodule Elastix.Index do
   @doc false
   def create(elastic_url, name, data) do
     elastic_url <> make_path(name)
-    |> HTTP.post(Poison.encode!(data))
+    |> HTTP.put(Poison.encode!(data))
     |> process_response
   end
 


### PR DESCRIPTION
ElasticSearch 5.x only supports PUT requests for creating indexes. This should be backward compatible with previous versions. 