### PR TITLE
Add bulk requests support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+### Improvements:
+
+  - add support for bulk requests
+
 ## 0.3.0
 
 ### Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
-## 0.4.0
-
-### Improvements:
-
-  - add support for bulk requests
-
 ## 0.3.0
 
 ### Improvements:
 
   - add support for mappings
+  - add support for bulk requests
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ When needed, the payload can be provided as an Elixir Map, which is internally c
 
 ## Overview
 
-Elastix has *3 main modules* and one *utility module*, that can be used, if the call/feature you want is not implemented (yet). However – please open issues or provide pull requests so I can improve the software for everybody. The modules are:
+Elastix has *4 main modules* and one *utility module*, that can be used, if the call/feature you want is not implemented (yet). However – please open issues or provide pull requests so I can improve the software for everybody. The modules are:
 
 * [Elastix.Index](lib/elastix/index.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html)
 * [Elastix.Document](lib/elastix/document.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html)
 * [Elastix.Search](lib/elastix/search.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html)
+* [Elastix.Bulk](lib/elastix/bulk.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
 * and [Elastix.HTTP](lib/elastix/http.ex) – a thin [HTTPoison](https://github.com/edgurgel/httpoison) wrapper
 
 I will try and provide documentation and examples for all of them with time, for now just consult the source code.
@@ -79,6 +80,46 @@ Elastix.Document.index(elastic_url, index_name, doc_type, product.id, index_data
 Elastix.Search.search(elastic_url, index_name, search_in, search_payload)
 Elastix.Document.delete(elastic_url, index_name, doc_type, product.id)
 
+```
+
+### Bulk request
+
+It is possible to execute `bulk` requests with *elastix*.
+
+Bulk requests take as parameters the list of lines to send to *Elasticsearch*. You can also optionally give them options. Available options are:
+
+* `index` the index of the request
+* `type` the document type of the request. *(you can't specify `type` without specifying `index`)*
+
+**Examples**
+
+```elixir
+lines = [
+  %{index: %{_id: "1"}},
+  %{field: "value1"},
+  %{index: %{_id: "2"}},
+  %{field: "value2"}
+]
+
+# Send bulk data
+Elastix.Bulk.post elastic_url, lines, index: "my_index", type: "my_type"
+# Send your lines by transforming them to iolist
+Elastix.Bulk.post_to_iolist elastic_url, lines, index: "my_index", type: "my_type"
+
+# Send raw data directly to the API
+data = Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+
+Elastix.Bulk.post_raw elastic_url, data, index: "my_index", type: "my_type"
+
+# Finally, you can specify the index or the type directly in you lines
+lines = [
+  %{index: %{_id: "1", _index: "my_index", _type: "my_type"}},
+  %{field: "value1"},
+  %{index: %{_id: "2", _index: "my_other_index", _type: "my_other_type"}},
+  %{field: "value2"}
+]
+
+Elastix.Bulk.post elastic_url, lines
 ```
 
 ## Configuration

--- a/lib/elastix/bulk.ex
+++ b/lib/elastix/bulk.ex
@@ -1,0 +1,50 @@
+defmodule Elastix.Bulk do
+  @moduledoc """
+  """
+  alias Elastix.HTTP
+
+  def post(elastic_url, lines, options \\ [], query_params \\ []) do
+    elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
+    |> HTTP.put(Enum.reduce(lines, "", fn (line, payload) -> payload <> Poison.encode!(line) <> "\n" end))
+    |> process_response
+  end
+
+  def post_to_iolist(elastic_url, lines, options \\ [], query_params \\ []) do
+    elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
+    |> HTTP.put(Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end))
+    |> process_response
+  end
+
+  @doc false
+  def post_raw(elastic_url, raw_data, options \\ [], query_params \\ []) do
+    elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
+    |> HTTP.put(raw_data)
+    |> process_response
+  end
+
+  @doc false
+  def make_path(index_name, type_name, query_params) do
+    path = _make_base_path(index_name, type_name)
+
+    case query_params do
+      [] -> path
+      _ -> add_query_params(path, query_params)
+    end
+  end
+
+  defp _make_base_path(nil, nil), do: "/_bulk"
+  defp _make_base_path(index_name, nil), do: "/#{index_name}/_bulk"
+  defp _make_base_path(index_name, type_name), do: "/#{index_name}/#{type_name}/_bulk"
+
+  @doc false
+  defp add_query_params(path, query_params) do
+    query_string = Enum.map_join query_params, "&", fn(param) ->
+      "#{elem(param, 0)}=#{elem(param, 1)}"
+    end
+
+    "#{path}?#{query_string}"
+  end
+
+  @doc false
+  defp process_response({_, response}), do: response
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Elastix.Mixfile do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [app: :elastix,

--- a/test/elastix/bulk_test.exs
+++ b/test/elastix/bulk_test.exs
@@ -1,0 +1,132 @@
+defmodule Elastix.BulkTest do
+  use ExUnit.Case
+  alias Elastix.Index
+  alias Elastix.Bulk
+  alias Elastix.Document
+
+  @test_url Elastix.config(:test_url)
+  @test_index Elastix.config(:test_index)
+
+  setup do
+    Index.delete(@test_url, @test_index)
+
+    :ok
+  end
+
+  test "make_path should make url from index name, type, and query params" do
+    assert Bulk.make_path(@test_index, "tweet", version: 34, ttl: "1d") == "/#{@test_index}/tweet/_bulk?version=34&ttl=1d"
+  end
+
+  test "make_path should make url from index name and query params" do
+    assert Bulk.make_path(@test_index, nil, version: 34, ttl: "1d") == "/#{@test_index}/_bulk?version=34&ttl=1d"
+  end
+
+  test "make_path should make url from query params" do
+    assert Bulk.make_path(nil, nil, version: 34, ttl: "1d") == "/_bulk?version=34&ttl=1d"
+  end
+
+  describe "test bulks with index and type in URL" do
+    setup do
+      {:ok, lines: [
+        %{index: %{_id: "1"}},
+        %{field: "value1"},
+        %{index: %{_id: "2"}},
+        %{field: "value2"}
+      ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      response = Bulk.post @test_url, lines, index: @test_index, type: "message"
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index, type: "message"
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      response = Bulk.post_to_iolist @test_url, lines, index: @test_index, type: "message"
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+
+  describe "test bulks with index only in URL" do
+    setup do
+      {:ok, lines: [
+        %{index: %{_id: "1", _type: "message"}},
+        %{field: "value1"},
+        %{index: %{_id: "2", _type: "message"}},
+        %{field: "value2"}
+      ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      response = Bulk.post @test_url, lines, index: @test_index
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      response = Bulk.post_to_iolist @test_url, lines, index: @test_index
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+
+  describe "test bulks without index nor type in URL" do
+    setup do
+      {:ok, lines: [
+        %{index: %{_id: "1", _type: "message", _index: @test_index}},
+        %{field: "value1"},
+        %{index: %{_id: "2", _type: "message", _index: @test_index}},
+        %{field: "value2"}
+      ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      response = Bulk.post @test_url, lines
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      response = Bulk.post_to_iolist @test_url, lines
+
+      assert response.status_code == 200
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
+      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+end


### PR DESCRIPTION
Adding bulk requests support with support for:

- index and type specified either in URL or in each line to send
- functions to post data either as string, iolist or directly as raw data