### PR TITLE
Don't strip the return atom

### DIFF
--- a/lib/elastix/bulk.ex
+++ b/lib/elastix/bulk.ex
@@ -6,20 +6,17 @@ defmodule Elastix.Bulk do
   def post(elastic_url, lines, options \\ [], query_params \\ []) do
     elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
     |> HTTP.put(Enum.reduce(lines, "", fn (line, payload) -> payload <> Poison.encode!(line) <> "\n" end))
-    |> process_response
   end
 
   def post_to_iolist(elastic_url, lines, options \\ [], query_params \\ []) do
     elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
     |> HTTP.put(Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end))
-    |> process_response
   end
 
   @doc false
   def post_raw(elastic_url, raw_data, options \\ [], query_params \\ []) do
     elastic_url <> make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params)
     |> HTTP.put(raw_data)
-    |> process_response
   end
 
   @doc false
@@ -44,7 +41,4 @@ defmodule Elastix.Bulk do
 
     "#{path}?#{query_string}"
   end
-
-  @doc false
-  defp process_response({_, response}), do: response
 end

--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -12,7 +12,6 @@ defmodule Elastix.Document do
   def index(elastic_url, index_name, type_name, id, data, query_params) do
     elastic_url <> make_path(index_name, type_name, id, query_params)
     |> HTTP.put(Poison.encode!(data))
-    |> process_response
   end
 
   @doc false
@@ -24,7 +23,6 @@ defmodule Elastix.Document do
   def index_new(elastic_url, index_name, type_name, data, query_params) do
     elastic_url <> make_path(index_name, type_name, query_params)
     |> HTTP.post(Poison.encode!(data))
-    |> process_response
   end
 
   @doc false
@@ -36,21 +34,18 @@ defmodule Elastix.Document do
   def get(elastic_url, index_name, type_name, id, query_params) do
     elastic_url <> make_path(index_name, type_name, id, query_params)
     |> HTTP.get
-    |> process_response
   end
 
   @doc false
   def delete(elastic_url, index_name, type_name, id) do
     elastic_url <> make_path(index_name, type_name, id, [])
     |> HTTP.delete
-    |> process_response
   end
 
   @doc false
   def delete(elastic_url, index_name, type_name, id, query_params) do
     elastic_url <> make_path(index_name, type_name, id, query_params)
     |> HTTP.delete
-    |> process_response
   end
 
   @doc false
@@ -71,7 +66,4 @@ defmodule Elastix.Document do
 
     "#{path}?#{query_string}"
   end
-
-  @doc false
-  defp process_response({_, response}), do: response
 end

--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -7,32 +7,29 @@ defmodule Elastix.Index do
   def create(elastic_url, name, data) do
     elastic_url <> make_path(name)
     |> HTTP.put(Poison.encode!(data))
-    |> process_response
   end
 
   @doc false
   def delete(elastic_url, name) do
     elastic_url <> make_path(name)
     |> HTTP.delete
-    |> process_response
   end
 
   @doc false
   def get(elastic_url, name) do
     elastic_url <> make_path(name)
     |> HTTP.get
-    |> process_response
   end
 
   @doc false
   def exists?(elastic_url, name) do
-    request = elastic_url <> make_path(name)
-      |> HTTP.head
-      |> process_response
-
-    case request.status_code do
-      200 -> true
-      404 -> false
+    case elastic_url <> make_path(name) |> HTTP.head do
+      {:ok, response} ->
+        case response.status_code do
+          200 -> {:ok, true}
+          404 -> {:ok, false}
+        end
+      err -> err
     end
   end
 
@@ -40,14 +37,10 @@ defmodule Elastix.Index do
   def refresh(elastic_url, name) do
     elastic_url <> make_path(name) <> make_path("_refresh")
     |> HTTP.post("")
-    |> process_response
   end
 
   @doc false
   def make_path(name) do
     "/#{name}"
   end
-
-  @doc false
-  defp process_response({_, response}), do: response
 end

--- a/lib/elastix/mapping.ex
+++ b/lib/elastix/mapping.ex
@@ -17,7 +17,6 @@ defmodule Elastix.Mapping do
   def put(elastic_url, index_names, type_name, data, query_params) when is_list(index_names) do
     elastic_url <> make_path(index_names, [type_name], query_params)
     |> HTTP.put(Poison.encode!(data))
-    |> process_response
   end
 
   @doc false
@@ -49,7 +48,6 @@ defmodule Elastix.Mapping do
   def get(elastic_url, index_names, type_names, query_params) when is_list(type_names) and is_list(index_names) do
     elastic_url <> make_path(index_names, type_names, query_params)
     |> HTTP.get
-    |> process_response
   end
 
   @doc false
@@ -76,7 +74,6 @@ defmodule Elastix.Mapping do
   def get_all(elastic_url, query_params) do
     elastic_url <> make_all_path(query_params)
     |> HTTP.get
-    |> process_response
   end
 
   @doc false
@@ -93,7 +90,6 @@ defmodule Elastix.Mapping do
   def get_all_with_type(elastic_url, type_names, query_params) when is_list(type_names) do
     elastic_url <> make_all_path(type_names, query_params)
     |> HTTP.get
-    |> process_response
   end
 
   @doc false
@@ -144,7 +140,4 @@ defmodule Elastix.Mapping do
 
     "#{path}?#{query_string}"
   end
-
-  @doc false
-  defp process_response({_, response}), do: response
 end

--- a/lib/elastix/search.ex
+++ b/lib/elastix/search.ex
@@ -12,7 +12,6 @@ defmodule Elastix.Search do
   def search(elastic_url, index, types, data, query_params) do
     elastic_url <> make_path(index, types, query_params)
     |> HTTP.post(Poison.encode!(data))
-    |> process_response
   end
 
   @doc false
@@ -40,7 +39,4 @@ defmodule Elastix.Search do
 
     "#{path}?#{query_string}"
   end
-
-  @doc false
-  defp process_response({_, response}), do: response
 end

--- a/test/elastix/bulk_test.exs
+++ b/test/elastix/bulk_test.exs
@@ -36,27 +36,27 @@ defmodule Elastix.BulkTest do
     end
 
     test "post bulk should execute it", %{lines: lines} do
-      response = Bulk.post @test_url, lines, index: @test_index, type: "message"
+      {:ok, response} = Bulk.post @test_url, lines, index: @test_index, type: "message"
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk with raw body should execute it", %{lines: lines} do
-      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index, type: "message"
+      {:ok, response} = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index, type: "message"
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk sending iolist should execute it", %{lines: lines} do
-      response = Bulk.post_to_iolist @test_url, lines, index: @test_index, type: "message"
+      {:ok, response} = Bulk.post_to_iolist @test_url, lines, index: @test_index, type: "message"
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 
@@ -71,27 +71,27 @@ defmodule Elastix.BulkTest do
     end
 
     test "post bulk should execute it", %{lines: lines} do
-      response = Bulk.post @test_url, lines, index: @test_index
+      {:ok, response} = Bulk.post @test_url, lines, index: @test_index
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk with raw body should execute it", %{lines: lines} do
-      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index
+      {:ok, response} = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end), index: @test_index
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk sending iolist should execute it", %{lines: lines} do
-      response = Bulk.post_to_iolist @test_url, lines, index: @test_index
+      {:ok, response} = Bulk.post_to_iolist @test_url, lines, index: @test_index
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 
@@ -106,27 +106,27 @@ defmodule Elastix.BulkTest do
     end
 
     test "post bulk should execute it", %{lines: lines} do
-      response = Bulk.post @test_url, lines
+      {:ok, response} = Bulk.post @test_url, lines
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk with raw body should execute it", %{lines: lines} do
-      response = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+      {:ok, response} = Bulk.post_raw @test_url, Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk sending iolist should execute it", %{lines: lines} do
-      response = Bulk.post_to_iolist @test_url, lines
+      {:ok, response} = Bulk.post_to_iolist @test_url, lines
 
       assert response.status_code == 200
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "1")
-      assert %{status_code: 200} = Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 end

--- a/test/elastix/document_test.exs
+++ b/test/elastix/document_test.exs
@@ -23,7 +23,7 @@ defmodule Elastix.DocumentTest do
   end
 
   test "index should create and index with data" do
-    response = Document.index @test_url, @test_index, "message", 1, @data
+    {:ok, response} = Document.index @test_url, @test_index, "message", 1, @data
 
     assert response.status_code == 201
     assert response.body["_id"] == "1"
@@ -33,7 +33,7 @@ defmodule Elastix.DocumentTest do
   end
 
   test "index_new should index data without an id" do
-    response = Document.index_new @test_url, @test_index, "message", @data
+    {:ok, response} = Document.index_new @test_url, @test_index, "message", @data
 
     assert response.status_code == 201
     assert response.body["_id"]
@@ -43,14 +43,14 @@ defmodule Elastix.DocumentTest do
   end
 
   test "get should return 404 if not index was created" do
-    response = Document.get @test_url, @test_index, "message", 1
+    {:ok, response} = Document.get @test_url, @test_index, "message", 1
 
     assert response.status_code == 404
   end
 
   test "get should return data with 200 after index" do
     Document.index @test_url, @test_index, "message", 1, @data
-    response = Document.get @test_url, @test_index, "message", 1
+    {:ok, response} = Document.get @test_url, @test_index, "message", 1
     body = response.body
 
     assert response.status_code == 200
@@ -62,13 +62,13 @@ defmodule Elastix.DocumentTest do
   test "delete should delete created index" do
     Document.index @test_url, @test_index, "message", 1, @data
 
-    response = Document.get @test_url, @test_index, "message", 1
+    {:ok, response} = Document.get @test_url, @test_index, "message", 1
     assert response.status_code == 200
 
-    response = Document.delete @test_url, @test_index, "message", 1
+    {:ok, response} = Document.delete @test_url, @test_index, "message", 1
     assert response.status_code == 200
 
-    response = Document.get @test_url, @test_index, "message", 1
+    {:ok, response} = Document.get @test_url, @test_index, "message", 1
     assert response.status_code == 404
   end
 end

--- a/test/elastix/index_test.exs
+++ b/test/elastix/index_test.exs
@@ -12,12 +12,12 @@ defmodule Elastix.IndexTest do
   end
 
   test "exists? should return false if index is not created" do
-    assert Index.exists?(@test_url, @test_index) == false
+    assert {:ok, false} == Index.exists?(@test_url, @test_index)
   end
 
   test "exists? should return true if index is created" do
-    assert Index.create(@test_url, @test_index, %{}).status_code == 200
-    assert Index.exists?(@test_url, @test_index) == true
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, true} == Index.exists?(@test_url, @test_index)
   end
 
   test "make_path should make path from id and url" do
@@ -25,35 +25,35 @@ defmodule Elastix.IndexTest do
   end
 
   test "create then delete should respond with 200" do
-    assert Index.create(@test_url, @test_index, %{}).status_code == 200
-    assert Index.delete(@test_url, @test_index).status_code == 200
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.delete(@test_url, @test_index)
   end
 
   test "double create should respond with 400" do
-    assert Index.create(@test_url, @test_index, %{}).status_code == 200
-    assert Index.create(@test_url, @test_index, %{}).status_code == 400
-    assert Index.delete(@test_url, @test_index).status_code == 200
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 400}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.delete(@test_url, @test_index)
   end
 
   test "get of uncreated index should respond with 404" do
-    assert Index.get(@test_url, @test_index).status_code == 404
+    assert {:ok, %{status_code: 404}} = Index.get(@test_url, @test_index)
   end
 
   test "get of created index should respond with 200 and index data" do
-    assert Index.create(@test_url, @test_index, %{}).status_code == 200
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
 
-    index = Index.get(@test_url, @test_index)
+    {:ok, index} = Index.get(@test_url, @test_index)
     assert index.status_code == 200
 
     assert index.body[@test_index]
   end
 
   test "refresh of uncreated index should respond with 404" do
-    assert Index.refresh(@test_url, @test_index).status_code == 404
+    assert {:ok, %{status_code: 404}} = Index.refresh(@test_url, @test_index)
   end
 
   test "refresh of existing index should respond with 200" do
-    Index.create(@test_url, @test_index, %{}).status_code
-    assert Index.refresh(@test_url, @test_index).status_code == 200
+    Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
   end
 end

--- a/test/elastix/mapping_test.exs
+++ b/test/elastix/mapping_test.exs
@@ -45,28 +45,28 @@ defmodule Elastix.MappingTest do
   end
 
   test "put mapping with no index should error" do
-    response = Mapping.put @test_url, @test_index, "message", @mapping
+    {:ok, response} = Mapping.put @test_url, @test_index, "message", @mapping
 
     assert response.status_code == 404
   end
 
   test "put should put mapping" do
     Index.create @test_url, @test_index, %{}
-    response = Mapping.put @test_url, @test_index, "message", @mapping
+    {:ok, response} = Mapping.put @test_url, @test_index, "message", @mapping
 
     assert response.status_code == 200
     assert response.body["acknowledged"] == true
   end
 
   test "get with non existing index should return error" do
-    response = Mapping.get @test_url, @test_index, "message"
+    {:ok, response} = Mapping.get @test_url, @test_index, "message"
 
     assert response.status_code == 404
   end
 
   test "get with non existing mapping should return nothing" do
     Index.create @test_url, @test_index, %{}
-    response = Mapping.get @test_url, @test_index, "message"
+    {:ok, response} = Mapping.get @test_url, @test_index, "message"
 
     assert response.status_code == 200
     assert response.body == %{}
@@ -75,7 +75,7 @@ defmodule Elastix.MappingTest do
   test "get mapping should return mapping" do
     Index.create @test_url, @test_index, %{}
     Mapping.put @test_url, @test_index, "message", @mapping
-    response = Mapping.get @test_url, @test_index, "message"
+    {:ok, response} = Mapping.get @test_url, @test_index, "message"
 
     assert response.status_code == 200
     assert response.body[@test_index]["mappings"]["message"] == @target_mapping
@@ -85,7 +85,7 @@ defmodule Elastix.MappingTest do
     Index.create @test_url, @test_index, %{}
     Mapping.put @test_url, @test_index, "message", @mapping
     Mapping.put @test_url, @test_index, "comment", @mapping
-    response = Mapping.get @test_url, @test_index, ["message", "comment"]
+    {:ok, response} = Mapping.get @test_url, @test_index, ["message", "comment"]
 
     assert response.status_code == 200
     assert response.body[@test_index]["mappings"]["message"] == @target_mapping
@@ -97,7 +97,7 @@ defmodule Elastix.MappingTest do
     Index.create @test_url, @test_index2, %{}
     Mapping.put @test_url, @test_index, "message", @mapping
     Mapping.put @test_url, @test_index2, "comment", @mapping
-    response = Mapping.get_all @test_url
+    {:ok, response} = Mapping.get_all @test_url
 
     assert response.status_code == 200
     assert response.body[@test_index]["mappings"]["message"] == @target_mapping
@@ -109,7 +109,7 @@ defmodule Elastix.MappingTest do
     Index.create @test_url, @test_index2, %{}
     Mapping.put @test_url, @test_index, "message", @mapping
     Mapping.put @test_url, @test_index2, "comment", @mapping
-    response = Mapping.get_all_with_type @test_url, ["message", "comment"]
+    {:ok, response} = Mapping.get_all_with_type @test_url, ["message", "comment"]
 
     assert response.status_code == 200
     assert response.body[@test_index]["mappings"]["message"] == @target_mapping
@@ -120,7 +120,7 @@ defmodule Elastix.MappingTest do
     Index.create @test_url, @test_index, %{}
     Mapping.put @test_url, @test_index, "message", @mapping
 
-    response = Document.index @test_url, @test_index, "message", 1, @data
+    {:ok, response} = Document.index @test_url, @test_index, "message", 1, @data
 
     assert response.status_code == 201
     assert response.body["_id"] == "1"

--- a/test/elastix/search_test.exs
+++ b/test/elastix/search_test.exs
@@ -32,7 +32,7 @@ defmodule Elastix.SearchTest do
         term: %{ user: "werbitzky" }
       }
     }
-    response = Search.search @test_url, @test_index, [], data
+    {:ok, response} = Search.search @test_url, @test_index, [], data
 
     assert response.status_code == 200
   end


### PR DESCRIPTION
This makes it possible to pattern match the responses

Fixes #26