### PR TITLE
Add Multi Get API

### DIFF
--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -36,6 +36,20 @@ defmodule Elastix.Document do
     |> HTTP.get
   end
 
+  @doc """
+  Get multiple documents matching the query using the Multi Get API.
+  """
+  def mget(elastic_url, query, index_name \\ nil, type_name \\ nil, query_params \\ []) do
+    path = [index_name, type_name]
+      |> Enum.filter(fn v -> v end) # Filter out nils.
+      |> Enum.join("/")
+    url = elastic_url <> "/#{path}/_mget"
+      |> add_query_params(query_params)
+
+    # HTTPoison does not provide an API for a GET request with a body.
+    HTTP.request(:get, url, Poison.encode!(query))
+  end
+
   @doc false
   def delete(elastic_url, index_name, type_name, id) do
     elastic_url <> make_path(index_name, type_name, [], id)

--- a/test/elastix/document_test.exs
+++ b/test/elastix/document_test.exs
@@ -88,4 +88,70 @@ defmodule Elastix.DocumentTest do
     assert body["_source"]["post_date"] == new_post_date
     assert body["_source"]["message"] == "trying out Elasticsearch"
   end
+
+  test "can get multiple documents (multi get)" do
+    Document.index @test_url, @test_index, "message", 1, @data
+    Document.index @test_url, @test_index, "message", 2, @data
+
+    query = %{"docs" =>
+      [
+        %{
+          "_index" => @test_index,
+          "_type" => "message",
+          "_id" => "1"
+        },
+        %{
+          "_index" => @test_index,
+          "_type" => "message",
+          "_id" => "2"
+        }
+      ]
+    }
+    {:ok, %{body: body, status_code: status_code}} = Document.mget @test_url, query
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
+
+  test "can get multiple documents (multi get with index)" do
+    Document.index @test_url, @test_index, "message", 1, @data
+    Document.index @test_url, @test_index, "message", 2, @data
+
+    query = %{"docs" =>
+      [
+        %{
+          "_type" => "message",
+          "_id" => "1"
+        },
+        %{
+          "_type" => "message",
+          "_id" => "2"
+        }
+      ]
+    }
+    {:ok, %{body: body, status_code: status_code}} = Document.mget @test_url, query, @test_index
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
+
+  test "can get multiple documents (multi get with index and type)" do
+    Document.index @test_url, @test_index, "message", 1, @data
+    Document.index @test_url, @test_index, "message", 2, @data
+
+    query = %{"docs" =>
+      [
+        %{
+          "_id" => "1"
+        },
+        %{
+          "_id" => "2"
+        }
+      ]
+    }
+    {:ok, %{body: body, status_code: status_code}} = Document.mget @test_url, query, @test_index, "message"
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
 end


### PR DESCRIPTION
This adds [Multi Get](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html) functionality.