### PR TITLE
Remove double backslash from Document.make_path

### DIFF
--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -72,9 +72,13 @@ defmodule Elastix.Document do
   end
 
   @doc false
-  def make_path(index_name, type_name, query_params, id \\ nil, suffix \\ nil) do
-    path = "/#{index_name}/#{type_name}/#{id}/#{suffix}"
-    add_query_params(path, query_params)
+  def make_path(index_name, type_name, query_params) do
+    "/#{index_name}/#{type_name}"
+    |> add_query_params(query_params)
+  end
+  def make_path(index_name, type_name, query_params, id, suffix \\ nil) do
+    "/#{index_name}/#{type_name}/#{id}/#{suffix}"
+    |> add_query_params(query_params)
   end
 
   @doc false

--- a/test/elastix/document_test.exs
+++ b/test/elastix/document_test.exs
@@ -22,6 +22,10 @@ defmodule Elastix.DocumentTest do
     assert Document.make_path(@test_index, "tweet", [version: 34, ttl: "1d"], 2, "_update") == "/#{@test_index}/tweet/2/_update?version=34&ttl=1d"
   end
 
+  test "make_path without and id should make url from index name, type, and query params" do
+    assert Document.make_path(@test_index, "tweet", [version: 34, ttl: "1d"]) == "/#{@test_index}/tweet?version=34&ttl=1d"
+  end
+
   test "index should create and index with data" do
     {:ok, response} = Document.index @test_url, @test_index, "message", 1, @data
 


### PR DESCRIPTION
Adds `Document.make_path/3` to ensure urls generated `Document.index_new` do not contain a trailing double slash.

#38 