### PR TITLE
CI version matrix and fix test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+# Elixir CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-elixir/ for more details
+version: 2
+shared: &shared
+  working_directory: ~/repo
+  steps:
+    - checkout
+
+    - run: mix local.hex --force
+    - run: mix local.rebar --force
+
+    - run: mix deps.get
+    - run: MIX_ENV=test mix compile
+
+    # Wait for Elasticsearch
+    - run:
+        command: |
+          while ! curl -sS --fail http://localhost:9200 > /dev/null 2>&1; do
+            sleep 1
+          done
+
+    - run: MIX_ENV=test mix test
+
+jobs:
+  "elasticsearch-5.6":
+    <<: *shared
+    docker:
+      - image: elixir:latest
+      - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.2
+        environment:
+          - discovery.type=single-node
+          - xpack.security.enabled=false
+
+  "elasticsearch-5.5":
+    <<: *shared
+    docker:
+      - image: elixir:latest
+      - image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+        environment:
+          - discovery.type=single-node
+          - xpack.security.enabled=false
+
+  "elasticsearch-5.4":
+    <<: *shared
+    docker:
+      - image: elixir:latest
+      - image: docker.elastic.co/elasticsearch/elasticsearch:5.4.3
+        environment:
+          - discovery.type=single-node
+          - xpack.security.enabled=false
+
+  "elasticsearch-5.3":
+    <<: *shared
+    docker:
+      - image: elixir:latest
+      - image: docker.elastic.co/elasticsearch/elasticsearch:5.3.3
+        environment:
+          - xpack.security.enabled=false
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "elasticsearch-5.6"
+      - "elasticsearch-5.5"
+      - "elasticsearch-5.4"
+      - "elasticsearch-5.3"


### PR DESCRIPTION
![screen shot 2017-10-07 at 12 56 27 pm](https://user-images.githubusercontent.com/181187/31307195-fa3c1836-ab5e-11e7-8afc-7d30fe7bc3a0.png)

This runs the tests against multiple Elasticsearch versions. This can be used to ensure that the tests pass for all supported versions of Elasticsearch. Also, this will be handy when Elasticsearch 6.0 is released. I tried running the tests agains 6.0.0-rc1 and a few tests fail. If you merge this then I'd be happy to get the tests ready for 6.0.

I'm using CircleCI instead of TravisCI because I find it to be easier to setup, it's very reliable, and it has great Docker support. And it's free for open source. I'm not affiliated with them.

If you decide to merge this, then you'll need to enable Circle CI. All you have to do is click the "Start building" button. See https://www.youtube.com/watch?v=KhjwnTD4oec .

Thanks! ✨ 