### PR TITLE
Option for using different JSON libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,22 @@ Currently we can
   * optionally use shield for authentication ([shield](https://www.elastic.co/products/shield))
   * optionally pass along custom headers for every request made to the elasticsearch server(s)s
   * optionally pass along options to [HTTPoison](https://github.com/edgurgel/httpoison)
+  * optionally use a different JSON library
 
 by setting the respective keys in your `config/config.exs`
 
 ```elixir
 config :elastix,
-  poison_options: [keys: :atoms],
+  json_options: [keys: :atoms],
   shield: true,
   username: "username",
   password: "password",
   httpoison_options: [hackney: [pool: :elastix_pool]]
 ```
+
+The above for example will
+  * lead to the HTTPoison responses being parsed into maps with atom keys instead of string keys (be careful as most of the time this is not a good idea as stated here: https://github.com/devinus/poison#parser).
+  * use shield for authentication
 
 ### Custom headers
 
@@ -172,9 +177,28 @@ defmodule MyModule do
 end
 ```
 
-The above for example will
-  * lead to the HTTPoison responses being parsed into maps with atom keys instead of string keys (be careful as most of the time this is not a good idea as stated here: https://github.com/devinus/poison#parser).
-  * use shield for authentication
+### Override the default JSON library
+
+To use a different JSON library you must pass in the json_codec option.
+
+For example:
+
+```elixir
+config :elastix,
+  json_codec: JiffyCodec,
+  json_options: [:return_maps]
+```
+
+This must be a module that implements the [Elastix.JSON.Codec](lib/elastix/json.ex) behavior.  For example:
+
+```elixir
+defmodule JiffyCodec do
+  @behaviour Elastix.JSON.Codec
+
+  def encode!(data), do: :jiffy.encode(data)
+  def decode(json, opts \\ []), do: {:ok, :jiffy.decode(json, opts)}
+end
+```
 
 ## Running tests
 

--- a/lib/elastix/bulk.ex
+++ b/lib/elastix/bulk.ex
@@ -2,7 +2,7 @@ defmodule Elastix.Bulk do
   @moduledoc """
   """
   import Elastix.HTTP, only: [prepare_url: 2]
-  alias Elastix.HTTP
+  alias Elastix.{HTTP, JSON}
 
   def post(elastic_url, lines, options \\ [], query_params \\ []) do
     elastic_url
@@ -11,13 +11,13 @@ defmodule Elastix.Bulk do
     |> HTTP.put(
       Enum.reduce(
         lines, "",
-        fn (line, payload) -> payload <> Poison.encode!(line) <> "\n" end))
+        fn (line, payload) -> payload <> JSON.encode!(line) <> "\n" end))
   end
 
   def post_to_iolist(elastic_url, lines, options \\ [], query_params \\ []) do
     elastic_url <> make_path(
       Keyword.get(options, :index), Keyword.get(options, :type), query_params)
-    |> HTTP.put(Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end))
+    |> HTTP.put(Enum.map(lines, fn line -> JSON.encode!(line) <> "\n" end))
   end
 
   @doc false

--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -2,7 +2,7 @@ defmodule Elastix.Document do
   @moduledoc """
   """
   import Elastix.HTTP, only: [prepare_url: 2]
-  alias Elastix.HTTP
+  alias Elastix.{HTTP, JSON}
 
   @doc false
   def index(elastic_url, index_name, type_name, id, data) do
@@ -12,7 +12,7 @@ defmodule Elastix.Document do
   @doc false
   def index(elastic_url, index_name, type_name, id, data, query_params) do
     prepare_url(elastic_url, make_path(index_name, type_name, query_params, id))
-    |> HTTP.put(Poison.encode!(data))
+    |> HTTP.put(JSON.encode!(data))
   end
 
   @doc false
@@ -23,7 +23,7 @@ defmodule Elastix.Document do
   @doc false
   def index_new(elastic_url, index_name, type_name, data, query_params) do
     prepare_url(elastic_url, make_path(index_name, type_name, query_params))
-    |> HTTP.post(Poison.encode!(data))
+    |> HTTP.post(JSON.encode!(data))
   end
 
   @doc false
@@ -48,7 +48,7 @@ defmodule Elastix.Document do
       |> add_query_params(query_params)
 
     # HTTPoison does not provide an API for a GET request with a body.
-    HTTP.request(:get, url, Poison.encode!(query))
+    HTTP.request(:get, url, JSON.encode!(query))
   end
 
   @doc false
@@ -63,14 +63,14 @@ defmodule Elastix.Document do
   def delete_matching(elastic_url, index_name, %{}=query, query_params \\ []) do
     prepare_url(elastic_url, [index_name, "_delete_by_query"])
     |> add_query_params(query_params)
-    |> HTTP.post(Poison.encode!(query))
+    |> HTTP.post(JSON.encode!(query))
   end
 
   @doc false
   def update(elastic_url, index_name, type_name, id, data, query_params \\ []) do
     elastic_url
     |> prepare_url(make_path(index_name, type_name, query_params, id, "_update"))
-    |> HTTP.post(Poison.encode!(data))
+    |> HTTP.post(JSON.encode!(data))
   end
 
   @doc false

--- a/lib/elastix/http.ex
+++ b/lib/elastix/http.ex
@@ -2,6 +2,7 @@ defmodule Elastix.HTTP do
   @moduledoc """
   """
   use HTTPoison.Base
+  alias Elastix.JSON
 
   @doc false
   def prepare_url(url, path) when is_binary(path),
@@ -42,14 +43,10 @@ defmodule Elastix.HTTP do
   @doc false
   def process_response_body(""), do: ""
   def process_response_body(body) do
-    case body |> to_string |> Poison.decode(poison_options()) do
+    case body |> to_string |> JSON.decode() do
       {:error, _} -> body
       {:ok, decoded} -> decoded
     end
-  end
-
-  defp poison_options do
-    Elastix.config(:poison_options, [])
   end
 
   defp default_httpoison_options do

--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -2,12 +2,12 @@ defmodule Elastix.Index do
   @moduledoc """
   """
   import Elastix.HTTP, only: [prepare_url: 2]
-  alias Elastix.HTTP
+  alias Elastix.{HTTP, JSON}
 
   @doc false
   def create(elastic_url, name, data) do
     prepare_url(elastic_url, name)
-    |> HTTP.put(Poison.encode!(data))
+    |> HTTP.put(JSON.encode!(data))
   end
 
   @doc false

--- a/lib/elastix/json.ex
+++ b/lib/elastix/json.ex
@@ -1,0 +1,56 @@
+defmodule Elastix.JSON do
+  defmodule Codec do
+    @callback encode!(data :: any) :: iodata
+
+    @callback decode(json :: iodata, opts :: []) :: {:ok, any} | {:error, :invalid}
+  end
+
+  @moduledoc """
+  A wrapper for JSON libraries with Poison as the default implementation.
+
+  To override, implement the Elastix.JSON.Codec behavior and specify it in application config like:
+
+  ```
+  config :elastix,
+    json_codec: JiffyCodec
+  ```
+
+  Decode options can be specified in application config like:
+
+  ```
+  # Poison decode with atom keys
+  config :elastix,
+    json_options: [keys: atoms!]
+  ```
+
+  ```
+  # Jiffy decode with maps
+  config :elastix,
+    json_codec: JiffyCodec,
+    json_options: [:return_maps]
+  ```
+  """
+
+  @doc false
+  def encode!(data) do
+    codec().encode!(data)
+  end
+
+  @doc false
+  def decode(json) do
+    codec().decode(json, json_options())
+  end
+
+  @doc false
+  defp json_options() do
+    # support poison_options config
+    case Elastix.config(:poison_options) do
+      nil -> Elastix.config(:json_options, [])
+      opts -> opts
+    end
+  end
+
+  defp codec() do
+    Elastix.config(:json_codec, Poison)
+  end
+end

--- a/lib/elastix/search.ex
+++ b/lib/elastix/search.ex
@@ -2,7 +2,7 @@ defmodule Elastix.Search do
   @moduledoc """
   """
   import Elastix.HTTP, only: [prepare_url: 2]
-  alias Elastix.HTTP
+  alias Elastix.{HTTP, JSON}
 
   @doc false
   def search(elastic_url, index, types, data) do
@@ -12,13 +12,13 @@ defmodule Elastix.Search do
   @doc false
   def search(elastic_url, index, types, data, query_params, options \\ []) do
     prepare_url(elastic_url, make_path(index, types, query_params))
-    |> HTTP.post(Poison.encode!(data), [], options)
+    |> HTTP.post(JSON.encode!(data), [], options)
   end
 
   @doc false
   def scroll(elastic_url, data, options \\ []) do
     prepare_url(elastic_url, "_search/scroll")
-    |> HTTP.post(Poison.encode!(data), [], options)
+    |> HTTP.post(JSON.encode!(data), [], options)
   end
 
   @doc false
@@ -29,7 +29,7 @@ defmodule Elastix.Search do
   @doc false
   def count(elastic_url, index, types, data, query_params, options \\ []) do
     elastic_url <> make_path(index, types, query_params, "_count")
-    |> HTTP.post(Poison.encode!(data), [], options)
+    |> HTTP.post(JSON.encode!(data), [], options)
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Elastix.Mixfile do
     [{:ex_doc, "~> 0.14", only: :dev},
      {:credo, "~> 0.6", only: [:dev, :test]},
      {:mix_test_watch, "~> 0.3", only: [:test, :dev]},
-     {:poison, "~> 3.1"},
+     {:poison, "~> 3.1", optional: true},
      {:httpoison, ">= 0.7.0"}]
   end
 


### PR DESCRIPTION
Provides a config option to override the default Poison JSON library by implementing a behavior.  The config key `poison_options` is still evaluated for backwards compatibility.