### PR TITLE
Add functions to take and restore ES snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ elixir:
   - 1.3.3
 services:
   - elasticsearch
+before_script:
+  - 'echo "path.repo /tmp" | sudo tee -a /etc/elasticsearch/elasticsearch.yml'
 script: "mix test"
 notifications:
   email: werbitzky@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ elixir:
 services:
   - elasticsearch
 before_script:
-  - 'echo "path.repo /tmp" | sudo tee -a /etc/elasticsearch/elasticsearch.yml'
+  - 'echo "path.repo: /tmp" | sudo tee -a /etc/elasticsearch/elasticsearch.yml'
   - 'sudo service elasticsearch restart'
 script: "mix test"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - elasticsearch
 before_script:
   - 'echo "path.repo /tmp" | sudo tee -a /etc/elasticsearch/elasticsearch.yml'
+  - 'sudo service elasticsearch restart'
 script: "mix test"
 notifications:
   email: werbitzky@gmail.com

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Elastix has *5 main modules* and one *utility module*, that can be used, if the 
 * [Elastix.Search](lib/elastix/search.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html)
 * [Elastix.Bulk](lib/elastix/bulk.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
 * [Elastix.Mapping](lib/elastix/mapping.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html)
+* [Elastix.Snapshot.Repository](lib/elastix/snapshot/repository.ex) and [Elastix.Snapshot.Snapshot](lib/elastix/snapshot/snapshot.ex) corresponding to: [this official API Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
 * and [Elastix.HTTP](lib/elastix/http.ex) – a thin [HTTPoison](https://github.com/edgurgel/httpoison) wrapper
 
 I will try and provide documentation and examples for all of them with time, for now just consult the source code.

--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -39,4 +39,16 @@ defmodule Elastix.Index do
     prepare_url(elastic_url, [name, "_refresh"])
     |> HTTP.post("")
   end
+
+  @doc false
+  def open(elastic_url, name) do
+    prepare_url(elastic_url, [name, "_open"])
+    |> HTTP.post("")
+  end
+
+  @doc false
+  def close(elastic_url, name) do
+    prepare_url(elastic_url, [name, "_close"])
+    |> HTTP.post("")
+  end
 end

--- a/lib/elastix/snapshot/repository.ex
+++ b/lib/elastix/snapshot/repository.ex
@@ -1,0 +1,74 @@
+defmodule Elastix.Snapshot.Repository do
+  @moduledoc """
+  Functions for working with repositories. A repository is required for taking
+  and restoring snapshots of indices.
+  """
+
+  import Elastix.HTTP, only: [prepare_url: 2]
+  alias Elastix.{HTTP, JSON}
+
+  @doc """
+  Registers a repository.
+  """
+  @spec register(String.t(), String.t(), Map.t(), [tuple()]) :: {:ok, %HTTPoison.Response{}}
+  def register(elastic_url, repo_name, data, query_params \\ []) do
+    elastic_url
+    |> prepare_url(make_path(repo_name, query_params))
+    |> HTTP.put(JSON.encode!(data))
+  end
+
+  @doc """
+  Verifies a registered but unverified repository.
+  """
+  @spec verify(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def verify(elastic_url, repo_name) do
+    elastic_url
+    |> prepare_url([make_path(repo_name), "_verify"])
+    |> HTTP.post("")
+  end
+
+  @doc """
+  If repo_name specified, will retrieve information about a registered repository.
+  Otherwise, will retrieve information about all repositories.
+  """
+  @spec get(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def get(elastic_url, repo_name \\ "_all") do
+    elastic_url
+    |> prepare_url(make_path(repo_name))
+    |> HTTP.get()
+  end
+
+  @doc """
+  Removes the reference to the location where the snapshots are stored.
+  """
+  @spec delete(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def delete(elastic_url, repo_name) do
+    elastic_url
+    |> prepare_url(make_path(repo_name))
+    |> HTTP.delete()
+  end
+
+  @doc false
+  @spec make_path(String.t(), [tuple()]) :: String.t()
+  def make_path(repo_name, query_params \\ []) do
+    path = _make_base_path(repo_name)
+
+    case query_params do
+      [] -> path
+      _ -> _add_query_params(path, query_params)
+    end
+  end
+
+  defp _make_base_path(nil), do: "/_snapshot"
+  defp _make_base_path(repo_name), do: "/_snapshot/#{repo_name}"
+
+  defp _add_query_params(path, query_params) do
+    query_string =
+      query_params
+      |> Enum.map_join("&", fn param ->
+        "#{elem(param, 0)}=#{elem(param, 1)}"
+      end)
+
+    "#{path}?#{query_string}"
+  end
+end

--- a/lib/elastix/snapshot/repository.ex
+++ b/lib/elastix/snapshot/repository.ex
@@ -2,6 +2,8 @@ defmodule Elastix.Snapshot.Repository do
   @moduledoc """
   Functions for working with repositories. A repository is required for taking
   and restoring snapshots of indices.
+
+  [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
   """
 
   import Elastix.HTTP, only: [prepare_url: 2]

--- a/lib/elastix/snapshot/snapshot.ex
+++ b/lib/elastix/snapshot/snapshot.ex
@@ -1,0 +1,90 @@
+defmodule Elastix.Snapshot.Snapshot do
+  @moduledoc """
+  Functions for working with snapshots.
+  """
+
+  import Elastix.HTTP, only: [prepare_url: 2]
+  alias Elastix.{HTTP, JSON}
+
+  @doc """
+  Creates a snapshot.
+  """
+  @spec create(String.t(), String.t(), String.t(), Map.t(), [tuple()]) ::
+          {:ok, %HTTPoison.Response{}}
+  def create(elastic_url, repo_name, snapshot_name, data \\ %{}, query_params \\ []) do
+    elastic_url
+    |> prepare_url(make_path(repo_name, snapshot_name, query_params))
+    |> HTTP.put(JSON.encode!(data))
+  end
+
+  @doc """
+  Restores a previously created snapshot.
+  """
+  @spec restore(String.t(), String.t(), String.t(), Map.t()) :: {:ok, %HTTPoison.Response{}}
+  def restore(elastic_url, repo_name, snapshot_name, data \\ %{}) do
+    elastic_url
+    |> prepare_url([make_path(repo_name, snapshot_name), "_restore"])
+    |> HTTP.post(JSON.encode!(data))
+  end
+
+  @doc """
+  If repo_name and snapshot_name is specified, will retrieve the status of that
+  snapsot. If repo_name is specified, will retrieve the status of all snapshots
+  in that repository. Otherwise, will retrieve the status of all snapshots.
+  """
+  @spec status(String.t(), String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def status(elastic_url, repo_name \\ "", snapshot_name \\ "") do
+    elastic_url
+    |> prepare_url([make_path(repo_name, snapshot_name), "_status"])
+    |> HTTP.get()
+  end
+
+  @doc """
+  If repo_name and snapshot_name is specified, will retrieve information about
+  that snapshot. If repo_name is specified, will retrieve information about
+  all snapshots in that repository. Oterwise, will retrieve information about
+  all snapshots.
+  """ 
+  @spec get(String.t(), String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def get(elastic_url, repo_name \\ "", snapshot_name \\ "_all") do
+    elastic_url
+    |> prepare_url(make_path(repo_name, snapshot_name))
+    |> HTTP.get()
+  end
+
+  @doc """
+  Deletes a snapshot from a repository. This can also be used to stop currently
+  running snapshot and restore operations.
+  """
+  @spec delete(String.t(), String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
+  def delete(elastic_url, repo_name, snapshot_name) do
+    elastic_url
+    |> prepare_url(make_path(repo_name, snapshot_name))
+    |> HTTP.delete()
+  end
+
+  @doc false
+  @spec make_path(String.t(), [tuple()]) :: String.t()
+  def make_path(repo_name, snapshot_name, query_params \\ []) do
+    path = _make_base_path(repo_name, snapshot_name)
+
+    case query_params do
+      [] -> path
+      _ -> _add_query_params(path, query_params)
+    end
+  end
+
+  defp _make_base_path(nil, nil), do: "/_snapshot"
+  defp _make_base_path(repo_name, nil), do: "/_snapshot/#{repo_name}"
+  defp _make_base_path(repo_name, snapshot_name), do: "/_snapshot/#{repo_name}/#{snapshot_name}"
+
+  defp _add_query_params(path, query_params) do
+    query_string =
+      query_params
+      |> Enum.map_join("&", fn param ->
+        "#{elem(param, 0)}=#{elem(param, 1)}"
+      end)
+
+    "#{path}?#{query_string}"
+  end
+end

--- a/lib/elastix/snapshot/snapshot.ex
+++ b/lib/elastix/snapshot/snapshot.ex
@@ -1,6 +1,8 @@
 defmodule Elastix.Snapshot.Snapshot do
   @moduledoc """
   Functions for working with snapshots.
+
+  [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
   """
 
   import Elastix.HTTP, only: [prepare_url: 2]

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Elastix.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :httpoison]]
+    [applications: [:logger, :httpoison, :retry]]
   end
 
   # Dependencies can be Hex packages:
@@ -35,7 +35,8 @@ defmodule Elastix.Mixfile do
      {:credo, "~> 0.6", only: [:dev, :test]},
      {:mix_test_watch, "~> 0.3", only: [:test, :dev]},
      {:poison, "~> 3.1", optional: true},
-     {:httpoison, ">= 0.7.0"}]
+     {:httpoison, ">= 0.7.0"},
+     {:retry, "~>0.8"}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], []},
   "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], []},
@@ -13,6 +14,8 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "retry": {:hex, :retry, "0.8.1", "46bd45c98dcba126bee04967d60f84ac13b854dfedaf6c2fb3b7f0cae884e090", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
+}

--- a/test/elastix/index_test.exs
+++ b/test/elastix/index_test.exs
@@ -49,7 +49,19 @@ defmodule Elastix.IndexTest do
   end
 
   test "refresh of existing index should respond with 200" do
-    Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
     assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+  end
+  
+  test "open of existing index should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+    assert {:ok, %{status_code: 200}} = Index.open(@test_url, @test_index)
+  end
+
+  test "close of existing index should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+    assert {:ok, %{status_code: 200}} = Index.close(@test_url, @test_index)
   end
 end

--- a/test/elastix/snapshot/repository_test.exs
+++ b/test/elastix/snapshot/repository_test.exs
@@ -1,0 +1,106 @@
+defmodule Elastix.Snapshot.RepositoryTest do
+  @moduledoc """
+  Tests for the Elastix.Snapshot.Repository module functions.
+
+  Note that for these tests to run, Elasticsearch must be running and the
+  elasticsearch.yml file must have the following entry:
+
+    path.repo /tmp
+  """
+
+  use ExUnit.Case
+  alias Elastix.Snapshot.Repository
+
+  @test_url Elastix.config(:test_url)
+  @test_repository_config %{type: "fs", settings: %{location: "/tmp"}}
+
+  setup do
+    on_exit(fn ->
+      Repository.delete(@test_url, "elastix_test_repository_1")
+      Repository.delete(@test_url, "elastix_test_repository_2")
+    end)
+
+    :ok
+  end
+
+  describe "constructing paths" do
+    test "make_path should make url from repository name and query params" do
+      assert Repository.make_path("elastix_test_unverified_backup", verify: false) ==
+               "/_snapshot/elastix_test_unverified_backup?verify=false"
+    end
+
+    test "make_path should make url from repository_name" do
+      assert Repository.make_path("elastix_test_repository_1") ==
+               "/_snapshot/elastix_test_repository_1"
+    end
+  end
+
+  describe "registering a repository" do
+    test "a repository" do
+      assert {:ok, %{status_code: 200}} =
+               Repository.register(
+                 @test_url,
+                 "elastix_test_repository_1",
+                 @test_repository_config
+               )
+    end
+
+    test "an unverified repository" do
+      assert {:ok, %{status_code: 200}} =
+               Repository.register(
+                 @test_url,
+                 "elastix_test_repository_1",
+                 @test_repository_config,
+                 verify: false
+               )
+    end
+  end
+
+  describe "verifying a repository" do
+    test "a registered but unverified repository is manually verified" do
+      Repository.register(
+        @test_url,
+        "elastix_test_repository_1",
+        @test_repository_config,
+        verify: false
+      )
+
+      assert {:ok, %{status_code: 200, body: %{"nodes" => _}}} =
+               Repository.verify(@test_url, "elastix_test_repository_1")
+    end
+  end
+
+  describe "retrieving information about a repository" do
+    test "repository doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Repository.get(@test_url, "nonexistent")
+    end
+
+    test "information about all repositories" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+      Repository.register(@test_url, "elastix_test_repository_2", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} = Repository.get(@test_url)
+    end
+
+    test "information about a specific repository" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} = Repository.get(@test_url, "elastix_test_repository_1")
+    end
+  end
+
+  describe "deleting a repository" do
+    test "repository doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Repository.delete(@test_url, "nonexistent")
+    end
+
+    test "references to the location where snapshots are stored are removed" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} =
+               Repository.delete(@test_url, "elastix_test_repository_1")
+
+      assert {:ok, %{status_code: 404}} = Repository.get(@test_url, "elastix_test_repository_1")
+    end
+  end
+end

--- a/test/elastix/snapshot/repository_test.exs
+++ b/test/elastix/snapshot/repository_test.exs
@@ -5,7 +5,7 @@ defmodule Elastix.Snapshot.RepositoryTest do
   Note that for these tests to run, Elasticsearch must be running and the
   elasticsearch.yml file must have the following entry:
 
-    path.repo /tmp
+    path.repo: /tmp
   """
 
   use ExUnit.Case

--- a/test/elastix/snapshot/snapshot_test.exs
+++ b/test/elastix/snapshot/snapshot_test.exs
@@ -5,7 +5,7 @@ defmodule Elastix.Snapshot.SnapshotTest do
   Note that for these tests to run, Elasticsearch must be running and the
   elasticsearch.yml file must have the following entry:
 
-    path.repo /tmp
+    path.repo: /tmp
 
   For testing purposes, snapshots are limited to test indices only.
   """

--- a/test/elastix/snapshot/snapshot_test.exs
+++ b/test/elastix/snapshot/snapshot_test.exs
@@ -1,0 +1,220 @@
+defmodule Elastix.Snapshot.SnapshotTest do
+  @moduledoc """
+  Tests for the Elastix.Snapshot.Snapshot module functions.
+
+  Note that for these tests to run, Elasticsearch must be running and the
+  elasticsearch.yml file must have the following entry:
+
+    path.repo /tmp
+
+  For testing purposes, snapshots are limited to test indices only.
+  """
+
+  use ExUnit.Case
+  alias Elastix.Index
+  alias Elastix.Snapshot.{Repository, Snapshot}
+
+  @test_url Elastix.config(:test_url)
+  @test_repository "elastix_test_repository"
+
+  setup_all do
+    Index.create(@test_url, "elastix_test_index_1", %{})
+    Index.create(@test_url, "elastix_test_index_2", %{})
+
+    Repository.register(@test_url, @test_repository, %{
+      type: "fs",
+      settings: %{
+        location: "/tmp",
+        max_snapshot_bytes_per_sec: "200mb",
+        max_restore_bytes_per_sec: "200mb"
+      }
+    })
+
+    :ok
+  end
+
+  setup do
+    on_exit(fn ->
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_1")
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_2")
+    end)
+
+    :ok
+  end
+
+  describe "constructing paths" do
+    test "make_path should make url from repository name, snapshot name, and query params" do
+      assert Snapshot.make_path(
+               @test_repository,
+               "elastix_test_snapshot_1",
+               wait_for_completion: true
+             ) ==
+               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1?wait_for_completion=true"
+    end
+
+    test "make_path should make url from repository name and snapshot name" do
+      assert Snapshot.make_path(@test_repository, "elastix_test_snapshot_1") ==
+               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1"
+    end
+  end
+
+  describe "creating a snapshot" do
+    test "a snapshot of multiple indices in the cluster" do
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.create(
+                 @test_url,
+                 @test_repository,
+                 "elastix_test_snapshot_1",
+                 %{
+                   indices: ["elastix_test_index_1", "elastix_test_index_2"]
+                 },
+                 wait_for_completion: true
+               )
+
+      Process.sleep(1000)
+
+      assert {:ok, %{body: %{"snapshots" => snapshots}}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+      snapshot =
+        Enum.find(snapshots, fn snapshot -> snapshot["snapshot"] == "elastix_test_snapshot_1" end)
+
+      assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
+      assert Enum.member?(snapshot["indices"], "elastix_test_index_2")
+    end
+
+    test "a snapshot of a single index in the cluster" do
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.create(
+                 @test_url,
+                 @test_repository,
+                 "elastix_test_snapshot_1",
+                 %{
+                   indices: ["elastix_test_index_1"]
+                 },
+                 wait_for_completion: true
+               )
+
+      Process.sleep(1000)
+
+      assert {:ok, %{body: %{"snapshots" => snapshots}}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+      snapshot =
+        Enum.find(snapshots, fn snapshot -> snapshot["snapshot"] == "elastix_test_snapshot_1" end)
+
+      assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
+      refute Enum.member?(snapshot["indices"], "elastix_test_index_2")
+    end
+  end
+
+  describe "restoring a snapshot" do
+    test "all indices in a snapshot" do
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.create(
+                 @test_url,
+                 @test_repository,
+                 "elastix_test_snapshot_1",
+                 %{indices: ["elastix_test_index_1", "elastix_test_index_2"]},
+                 wait_for_completion: true
+               )
+
+      Process.sleep(1000)
+
+      Index.delete(@test_url, "elastix_test_index_1")
+      Index.delete(@test_url, "elastix_test_index_2")
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+      assert {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_1")
+      assert {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_2")
+    end
+
+    test "a specific index in a snapshot" do
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.create(
+                 @test_url,
+                 @test_repository,
+                 "elastix_test_snapshot_1",
+                 %{indices: ["elastix_test_index_1", "elastix_test_index_2"]},
+                 wait_for_completion: true
+               )
+
+      Process.sleep(1000)
+
+      Index.delete(@test_url, "elastix_test_index_1")
+      Index.delete(@test_url, "elastix_test_index_2")
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_1", %{
+                 indices: "elastix_test_index_1"
+               })
+
+      assert {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_1")
+      assert {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_2")
+    end
+  end
+
+  describe "retrieving status information for a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Snapshot.get(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "information about all snapshots" do
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url)
+    end
+
+    test "information about all snapshots in a repository" do
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @test_repository)
+    end
+
+    test "information about a specific snapshot" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+    end
+  end
+
+  describe "retrieving information about a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Snapshot.get(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "information about all snapshots" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_1")
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_2")
+
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @test_repository)
+    end
+
+    test "information about a specific snapshot" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_1", %{
+        indices: ["elastix_test_index_1", "elastix_test_index_2"]
+      })
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+    end
+  end
+
+  describe "deleting a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.delete(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "snapshot is deleted" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_1", %{
+        indices: ["elastix_test_index_1", "elastix_test_index_2"]
+      })
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds two new modules, `Elastix.Snapshot.Repository` and `Elastix.Snapshot.Snapshot`, which implements functions for performing many of the actions detailed here: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html.

I also added two new functions, `Elastix.Index.open/2` and `Elastix.Index.close/2`. Existing indices need to be closed before they can be restored, so having these available made testing a bit easier.

One thing to note: on my local machine, I am running Docker-ised Elasticsearch. I have noticed that tests occasionally fail: sometimes snapshot creation in still in progress, so restore fails; sometimes not all shards are successfully snapshotted; etc. However it appears that Travis' Elasticsearch responds faster, so the tests behave.
