### PR TITLE
allow httpoison_options to be passed to bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0
+
+### Improvements
+
+ - Add support for custom httpoison options on bulk calls
+
 ## 0.6.1
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can also specify the following options:
 
 * `index` the index of the request
 * `type` the document type of the request. *(you can't specify `type` without specifying `index`)*
+* `httpoison_options` configuration directly passed to httpoison methods. Same options that can be passed on config file
 
 ```elixir
 lines = [
@@ -73,7 +74,7 @@ lines = [
   %{field: "value2"}
 ]
 
-Elastix.Bulk.post(elastic_url, lines, index: "my_index", type: "my_type")
+Elastix.Bulk.post(elastic_url, lines, index: "my_index", type: "my_type", httpoison_options: [timeout: 180_000])
 
 # You can also send raw data:
 data = Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)

--- a/lib/elastix/bulk.ex
+++ b/lib/elastix/bulk.ex
@@ -31,9 +31,11 @@ defmodule Elastix.Bulk do
       Keyword.get(options, :index)
       |> make_path(Keyword.get(options, :type), query_params)
 
+    httpoison_options = Keyword.get(options, :httpoison_options, [])
+
     elastic_url
     |> prepare_url(path)
-    |> HTTP.put(data)
+    |> HTTP.put(data, [], httpoison_options)
   end
 
   @doc """
@@ -50,9 +52,11 @@ defmodule Elastix.Bulk do
       "This function is deprecated and will be removed in future releases; use Elastix.Bulk.post/4 instead."
     )
 
+    httpoison_options = Keyword.get(options, :httpoison_options, [])
+
     (elastic_url <>
        make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params))
-    |> HTTP.put(Enum.map(lines, fn line -> JSON.encode!(line) <> "\n" end))
+    |> HTTP.put(Enum.map(lines, fn line -> JSON.encode!(line) <> "\n" end), [], httpoison_options)
   end
 
   @doc """
@@ -66,9 +70,12 @@ defmodule Elastix.Bulk do
           query_params :: Keyword.t()
         ) :: HTTP.resp()
   def post_raw(elastic_url, raw_data, options \\ [], query_params \\ []) do
+
+    httpoison_options = Keyword.get(options, :httpoison_options, [])
+
     (elastic_url <>
        make_path(Keyword.get(options, :index), Keyword.get(options, :type), query_params))
-    |> HTTP.put(raw_data)
+    |> HTTP.put(raw_data, [], httpoison_options)
   end
 
   @doc false

--- a/test/elastix/bulk_test.exs
+++ b/test/elastix/bulk_test.exs
@@ -27,6 +27,17 @@ defmodule Elastix.BulkTest do
     assert Bulk.make_path(nil, nil, version: 34, ttl: "1d") == "/_bulk?version=34&ttl=1d"
   end
 
+  test "bulk accepts httpoison options" do
+    lines = [
+        %{index: %{_id: "1"}},
+        %{field: "value1"},
+        %{index: %{_id: "2"}},
+        %{field: "value2"}
+      ]
+    {:error, %HTTPoison.Error{reason: :timeout}} =
+      Bulk.post @test_url, lines, index: @test_index, type: "message", httpoison_options: [recv_timeout: 0]
+  end
+
   describe "test bulks with index and type in URL" do
     setup do
       {:ok,


### PR DESCRIPTION
Hey!
i find myself in the need to customize the httpoison timeouts but only for bulk inserts.

This PR adds a new entry to the Bulk.put/4 options parameter, called `httpoison_options` following the same configurations for elastix in config.exs.
There is also the possibility to accept the params the same way that in Search module. This one seemed clearer.

Would you accept something like this? 

Thanks

Juan