### PR TITLE
Add support for Elasticsearch 7.0 and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # Elastix [![Hex Version](https://img.shields.io/hexpm/v/elastix.svg)](https://hex.pm/packages/elastix) [![Hex Downloads](https://img.shields.io/hexpm/dt/elastix.svg)](https://hex.pm/packages/elastix) [![Build Status](https://travis-ci.org/werbitzky/elastix.svg)](https://travis-ci.org/werbitzky/elastix) [![WTFPL](https://img.shields.io/badge/license-WTFPL-brightgreen.svg?style=flat)](https://www.tldrlegal.com/l/wtfpl)
 
-A DSL-free Elasticsearch client for Elixir.
+An Elasticsearch client for Elixir.
+
+This library has convenience functions for working with the Elasticsearch
+API. It does not use a DSL, it expects you to interact with the Elasticsearch
+using native JSON data structures, or the equivalent Elixir data structures which
+it will encode for you.
+
+It supports the new Elasticsearch 7.x as well as older versions.
+7.x has [removed mapping types on indexes](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html),
+which resulted in incompatible changes to a number of APIs.
 
 ## Documentation
 
 * [Documentation on hexdocs.pm](https://hexdocs.pm/elastix/)
 * [Latest Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
-
-Even though the [documentation](https://hexdocs.pm/elastix/) is pretty scarce right now, we're working on improving it. If you want to help with that you're definitely welcome 🤗
-
-This README contains most of the information you should need to get started, if you can't find what you're looking for, either look at the tests or file an issue!
 
 ## Installation
 
@@ -25,7 +30,7 @@ Then run `mix deps.get` to fetch the new dependency.
 
 ## Examples
 
-### Creating an Elasticsearch index
+### Creating an index
 
 ```elixir
 Elastix.Index.create("http://localhost:9200", "twitter", %{})
@@ -37,9 +42,9 @@ Elastix.Index.create("http://localhost:9200", "twitter", %{})
 elastic_url = "http://localhost:9200"
 
 data = %{
-    user: "kimchy",
-    post_date: "2009-11-15T14:12:12",
-    message: "trying out Elastix"
+  user: "kimchy",
+  post_date: "2009-11-15T14:12:12",
+  message: "trying out Elastix"
 }
 
 mapping = %{
@@ -58,7 +63,9 @@ Elastix.Document.delete(elastic_url, "twitter", "tweet", "42")
 
 ### Bulk requests
 
-Bulk requests take as parameter a list of the lines you want to send to the [`_bulk`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) endpoint.
+Bulk requests take as parameter a list of the lines you want to send to the
+[`_bulk`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
+endpoint.
 
 You can also specify the following options:
 
@@ -100,7 +107,9 @@ config :elastix,
   httpoison_options: [hackney: [pool: :elastix_pool]]
 ```
 
-Note that you can configure Elastix to use any JSON library, see the ["Custom JSON codec" page](https://hexdocs.pm/elastix/custom-json-codec.html) for more info.
+Note that you can configure Elastix to use any JSON library, see the
+["Custom JSON codec" page](https://hexdocs.pm/elastix/custom-json-codec.html) for more
+info.
 
 ### Custom headers
 
@@ -109,7 +118,10 @@ config :elastix,
   custom_headers: {MyModule, :add_aws_signature, ["us-east"]}
 ```
 
-`custom_headers` must be a tuple of the type `{Module, :function, [args]}`, where `:function` is a function that should accept the request (a map of this type: `%{method: String.t, headers: [], url: String.t, body: String.t}`) as its first parameter and return a list of the headers you want to send:
+`custom_headers` must be a tuple of the type `{Module, :function, [args]}`,
+where `:function` is a function that should accept the request (a map of this
+type: `%{method: String.t, headers: [], url: String.t, body: String.t}`) as its
+first parameter and return a list of the headers you want to send:
 
 ```elixir
 defmodule MyModule do
@@ -125,7 +137,8 @@ end
 
 ## Running tests
 
-You need Elasticsearch running locally on port 9200. A quick way of doing so is via Docker:
+You need Elasticsearch running locally on port 9200.
+A quick way of doing so is via Docker:
 
 ```
 $ docker run -p 9200:9200 -it --rm elasticsearch:5.1.2
@@ -142,6 +155,8 @@ $ mix test
 
 ## License
 
-Copyright © 2017 El Werbitzky werbitzky@gmail.com
+Copyright © 2017-2019 El Werbitzky werbitzky@gmail.com
 
-This work is free. You can redistribute it and/or modify it under the terms of the Do What The Fuck You Want To Public License, Version 2, as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+This work is free. You can redistribute it and/or modify it under the terms of
+the Do What The Fuck You Want To Public License, Version 2, as published by Sam
+Hocevar. See http://www.wtfpl.net/ for more details.

--- a/lib/elastix.ex
+++ b/lib/elastix.ex
@@ -19,4 +19,16 @@ defmodule Elastix do
 
   @doc false
   def config(key, default \\ nil), do: Application.get_env(:elastix, key, default)
+
+
+  @doc "Convert Elasticsearch version string into tuple."
+  def version_to_tuple(version) when is_binary(version) do
+    version
+    |> String.split([".", "-"])
+    |> Enum.map(&String.to_integer/1)
+    |> version_to_tuple()
+  end
+  def version_to_tuple([first, second]), do: {first, second, 0}
+  def version_to_tuple([first, second, third | _rest]), do: {first, second, third}
+
 end

--- a/lib/elastix/alias.ex
+++ b/lib/elastix/alias.ex
@@ -1,23 +1,27 @@
 defmodule Elastix.Alias do
   @moduledoc """
-  The alias API makes it possible to perform alias operations on indexes.
+  The alias API adds or removes index aliases, a secondary name used to refer
+  to one or more existing indices.
 
-  [Aliases documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html)
+  [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html)
   """
-  import Elastix.HTTP, only: [prepare_url: 2]
   alias Elastix.{HTTP, JSON}
 
   @doc """
-  Excepts a list of actions for the `actions` parameter.
+  Perform actions on aliases.
+
+  Specify the list of actions in the `actions` parameter.
 
   ## Examples
-      iex> actions = [%{ add: %{ index: "test1", alias: "alias1" }}]
+
+      iex> actions = [%{add: %{index: "test1", alias: "alias1"}}]
       iex> Elastix.Alias.post("http://localhost:9200", actions)
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec post(elastic_url :: String.t(), actions :: list) :: HTTP.resp()
+  @spec post(binary, [map]) :: HTTP.resp
   def post(elastic_url, actions) do
-    prepare_url(elastic_url, ["_aliases"])
-    |> HTTP.post(JSON.encode!(%{actions: actions}))
+    url = HTTP.make_url(elastic_url, "_aliases")
+    HTTP.post(url, JSON.encode!(%{actions: actions}))
   end
 end

--- a/lib/elastix/document.ex
+++ b/lib/elastix/document.ex
@@ -4,162 +4,209 @@ defmodule Elastix.Document do
 
   [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html)
   """
-  import Elastix.HTTP, only: [prepare_url: 2]
   alias Elastix.{HTTP, JSON}
 
   @doc """
-  (Re)Indexes a document with the given `id`.
+  Index document.
+
+  * `elastic_url`: base url for Elasticsearch server
+  * `index`: index name
+  * `data`: data to index, either a map or binary
+  * `metadata`:
+     - id`: document identifier. If not specified, Elasticsearch will generate one.
+     - `type`: document type
+       Type is obsolete in newer versions of Elasticsearch.
+       See [removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
 
   ## Examples
 
-      iex> Elastix.Document.index("http://localhost:9200", "twitter", "tweet", "42", %{user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastix"})
+  New API:
+
+      iex> data = %{user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastix"}
+      iex> index = "twitter"
+      iex> Elastix.Document.index("http://localhost:9200", index, data, %{id: "42", type: "tweet"})
       {:ok, %HTTPoison.Response{...}}
+
+  Old API:
+
+      iex> data = %{user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastix"}
+      iex> index = "twitter"
+      iex> type = "tweet"
+      iex> id = "42"
+      iex> Elastix.Document.index("http://localhost:9200", index, type, id, data)
+      {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec index(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          type :: String.t(),
-          id :: String.t(),
-          data :: map,
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def index(elastic_url, index_name, type_name, id, data, query_params \\ []) do
-    prepare_url(elastic_url, make_path(index_name, type_name, query_params, id))
-    |> HTTP.put(JSON.encode!(data))
+  # New: @spec index(binary, binary, map | binary, map | binary, Keyword.t) :: HTTP.resp
+  def index(elastic_url, index, data_or_type, metadata_or_id \\ %{}, data_or_query_params \\ [], query_params \\ [])
+
+  # New: @spec index(binary, binary, binary | map, map, Keyword.t) :: HTTP.resp
+  def index(elastic_url, index, data, %{id: _} = metadata, query_params, _unused) when is_map(metadata) do
+    url = HTTP.make_url(elastic_url, make_path(index, metadata), query_params)
+    HTTP.put(url, JSON.encode!(data))
+  end
+  def index(elastic_url, index, data, metadata, query_params, _unused) when is_map(metadata) do
+    url = HTTP.make_url(elastic_url, make_path(index, metadata), query_params)
+    HTTP.post(url, JSON.encode!(data)) # Use post to automatically assign id when not specified
+  end
+
+  # Old: @spec index(binary, binary, binary, binary, map, Keyword.t) :: HTTP.resp
+  def index(elastic_url, index, type, id, data, query_params) do
+    # TODO: Deprecation warning
+    url = HTTP.make_url(elastic_url, make_path_old(index, type, query_params, id))
+    HTTP.put(url, JSON.encode!(data))
+  end
+
+  # @doc deprecated: """
+  # Index a new document.
+  #
+  # ## Examples
+  #
+  #     iex> data = %{user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastix"}
+  #     iex> Elastix.Document.index_new("http://localhost:9200", "twitter", "tweet", data)
+  #     {:ok, %HTTPoison.Response{...}}
+  # """
+  @doc deprecated: "Use index/6 instead"
+  @spec index_new(binary, binary, binary, map, Keyword.t) :: HTTP.resp
+  def index_new(elastic_url, index, type, data, query_params \\ []) do
+    # TODO: deprecation warning
+    url = HTTP.make_url(elastic_url, make_path_old(index, type, query_params))
+    HTTP.post(url, JSON.encode!(data))
   end
 
   @doc """
-  Indexes a new document.
+  Get document by id.
 
   ## Examples
 
-      iex> Elastix.Document.index_new("http://localhost:9200", "twitter", "tweet", %{user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastix"})
+  New API without types:
+
+      iex> Elastix.Document.get("http://localhost:9200", "twitter", "42")
       {:ok, %HTTPoison.Response{...}}
-  """
-  @spec index_new(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          type :: String.t(),
-          data :: map,
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def index_new(elastic_url, index_name, type_name, data, query_params \\ []) do
-    prepare_url(elastic_url, make_path(index_name, type_name, query_params))
-    |> HTTP.post(JSON.encode!(data))
-  end
 
-  @doc """
-  Fetches a document matching the given `id`.
-
-  ## Examples
+  Old API with types:
 
       iex> Elastix.Document.get("http://localhost:9200", "twitter", "tweet", "42")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec get(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          type :: String.t(),
-          id :: String.t(),
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def get(elastic_url, index_name, type_name, id, query_params \\ []) do
-    prepare_url(elastic_url, make_path(index_name, type_name, query_params, id))
-    |> HTTP.get()
+  @spec get(binary, binary, binary, Keyword.t | binary, Keyword.t) :: HTTP.resp
+
+  def get(elastic_url, index, id_or_type, query_params_or_id \\ [], query_params \\ [])
+
+  # New API
+  def get(elastic_url, index, id, query_params, _unused) when is_list(query_params) do
+    url = HTTP.make_url(elastic_url, make_path(index, %{id: id}), query_params)
+    HTTP.get(url)
   end
 
+  # Old: @spec get(binary, binary, binary, binary, Keyword.t) :: HTTP.resp
+  def get(elastic_url, index, type, id, query_params) do
+    # TODO: deprecation warning
+    url = HTTP.make_url(elastic_url, make_path_old(index, type, query_params, id))
+    HTTP.get(url)
+  end
+
+
   @doc """
-  Fetches multiple documents matching the given `query` using the
+  Get multiple documents with the mget API.
+
   [Multi Get API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html).
   """
-  @spec mget(
-          elastic_url :: String.t(),
-          query :: map,
-          index :: String.t(),
-          type :: String.t(),
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def mget(elastic_url, query, index_name \\ nil, type_name \\ nil, query_params \\ []) do
-    path =
-      [index_name, type_name]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join("/")
 
-    url =
-      prepare_url(elastic_url, [path, "_mget"])
-      |> HTTP.append_query_string(query_params)
+  @spec mget(binary, map, binary | nil, binary | Keyword.t, Keyword.t) :: HTTP.resp
+  # Old: @spec mget(binary, map, binary | nil, binary | nil, Keyword.t) :: HTTP.resp
 
+  def mget(elastic_url, query, index \\ nil, query_params_or_type \\ [], query_params \\ [])
+
+  # New API
+  def mget(elastic_url, query, nil, query_params, _unused) when is_list(query_params) do
+    do_mget(elastic_url, query, ["_mget"], query_params)
+  end
+  def mget(elastic_url, query, index, query_params, _unused) when is_list(query_params) do
+    do_mget(elastic_url, query, [index, "_mget"], query_params)
+  end
+
+  # Old API
+  def mget(elastic_url, query, index, type, query_params) when is_binary(type) do
+    do_mget(elastic_url, query, [index, type, "_mget"], query_params)
+  end
+
+  defp do_mget(elastic_url, query, path_comps, query_params) do
+    url = HTTP.make_url(elastic_url, path_comps, query_params)
     # HTTPoison does not provide an API for a GET request with a body.
     HTTP.request(:get, url, JSON.encode!(query))
   end
 
   @doc """
-  Deletes the documents matching the given `id`.
+  Delete the documents matching the given `id`.
 
   ## Examples
 
       iex> Elastix.Document.delete("http://localhost:9200", "twitter", "tweet", "42")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec delete(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          type :: String.t(),
-          id :: String.t(),
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def delete(elastic_url, index_name, type_name, id, query_params \\ []) do
-    prepare_url(elastic_url, make_path(index_name, type_name, query_params, id))
-    |> HTTP.delete()
+  @spec delete(binary, binary, binary, Keyword.t | binary, Keyword.t) :: HTTP.resp
+
+  def delete(elastic_url, index, type_or_id, id_or_query_params \\ [], query_params \\ [])
+
+  def delete(elastic_url, index, id, query_params, _unused) when is_list(query_params) do
+    url = HTTP.make_url(elastic_url, make_path(index, %{id: id}), query_params)
+    HTTP.delete(url)
+  end
+
+  # Old: @spec delete(binary, binary, binary, binary, Keyword.t) :: HTTP.resp
+  def delete(elastic_url, index, type, id, query_params) when is_binary(id) or is_integer(id) do
+    url = HTTP.make_url(elastic_url, make_path_old(index, type, query_params, id))
+    HTTP.delete(url)
   end
 
   @doc """
-  Deletes the documents matching the given `query` using the
+  Delete the documents matching the given `query` using the
   [Delete By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html).
   """
-  @spec delete_matching(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          query :: map,
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def delete_matching(elastic_url, index_name, %{} = query, query_params \\ []) do
-    prepare_url(elastic_url, [index_name, "_delete_by_query"])
-    |> HTTP.append_query_string(query_params)
-    |> HTTP.post(JSON.encode!(query))
+  @spec delete_matching(binary, binary, map, Keyword.t) :: HTTP.resp
+  def delete_matching(elastic_url, index, %{} = query, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, [index, "_delete_by_query"], query_params)
+    HTTP.post(url, JSON.encode!(query))
   end
 
   @doc """
-  Updates the document with the given `id`.
+  Update the document with the given `id`.
 
   ## Examples
 
-      iex> Elastix.Document.update("http://localhost:9200", "twitter", "tweet", "42", %{user: "kimchy", message: "trying out Elastix.Document.update/5"})
+      iex> data = %{user: "kimchy", message: "trying out Elastix.Document.update/5"}
+      iex> Elastix.Document.update("http://localhost:9200", "twitter", "tweet", "42", data)
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec update(
-          elastic_url :: String.t(),
-          index :: String.t(),
-          type :: String.t(),
-          id :: String.t(),
-          data :: map,
-          query_params :: Keyword.t()
-        ) :: HTTP.resp()
-  def update(elastic_url, index_name, type_name, id, data, query_params \\ []) do
-    elastic_url
-    |> prepare_url(make_path(index_name, type_name, query_params, id, "_update"))
-    |> HTTP.post(JSON.encode!(data))
+  @spec update(binary, binary, binary, binary, map, Keyword.t) :: HTTP.resp
+  def update(elastic_url, index, type, id, data, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, make_path_old(index, type, query_params, id, "_update"))
+    HTTP.post(url, JSON.encode!(data))
   end
 
   @doc false
-  def make_path(index_name, type_name, query_params) do
-    "/#{index_name}/#{type_name}"
-    |> HTTP.append_query_string(query_params)
+  @spec make_path(binary, map) :: binary
+  def make_path(index, metadata \\ %{})
+  def make_path(index, %{id: id}), do: "/#{index}/_doc/#{id}"
+  def make_path(index, %{_id: id}), do: "/#{index}/_doc/#{id}"
+  def make_path(index, _), do: "/#{index}/_doc/"
+
+  @doc false
+  def make_path_old(index, type, query_params) do
+    HTTP.add_query_params("/#{index}/#{type}", query_params)
   end
 
   @doc false
-  def make_path(index_name, type_name, query_params, id, suffix \\ nil) do
-    "/#{index_name}/#{type_name}/#{id}/#{suffix}"
-    |> HTTP.append_query_string(query_params)
+  def make_path_old(index, type, query_params, id, suffix \\ nil)
+  def make_path_old(index, type, query_params, id, nil) do
+    HTTP.add_query_params("/#{index}/#{type}/#{id}", query_params)
   end
+  def make_path_old(index, type, query_params, id, suffix) do
+    HTTP.add_query_params("/#{index}/#{type}/#{id}/#{suffix}", query_params)
+  end
+
 end

--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -1,38 +1,40 @@
 defmodule Elastix.Index do
   @moduledoc """
-  The indices APIs are used to manage individual indices, index settings, aliases, mappings, and index templates.
+  The indices APIs are used to manage individual indices, index settings,
+  aliases, mappings, and index templates.
 
   [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html)
   """
-  import Elastix.HTTP, only: [prepare_url: 2]
   alias Elastix.{HTTP, JSON}
 
   @doc """
-  Creates a new index.
+  Create a new index.
 
   ## Examples
 
       iex> Elastix.Index.create("http://localhost:9200", "twitter", %{})
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec create(elastic_url :: String.t(), name :: String.t(), data :: map) :: HTTP.resp()
-  def create(elastic_url, name, data) do
-    prepare_url(elastic_url, name)
-    |> HTTP.put(JSON.encode!(data))
+  @spec create(binary, binary, map) :: HTTP.resp
+  def create(elastic_url, index, data) do
+    url = HTTP.make_url(elastic_url, index)
+    HTTP.put(url, JSON.encode!(data))
   end
 
   @doc """
-  Deletes an existing index.
+  Delete an existing index.
 
   ## Examples
 
       iex> Elastix.Index.delete("http://localhost:9200", "twitter")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec delete(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
-  def delete(elastic_url, name) do
-    prepare_url(elastic_url, name)
-    |> HTTP.delete()
+  @spec delete(binary, binary) :: HTTP.resp
+  def delete(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, index)
+    HTTP.delete(url)
   end
 
   @doc """
@@ -42,82 +44,89 @@ defmodule Elastix.Index do
 
       iex> Elastix.Index.get("http://localhost:9200", "twitter")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec get(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
-  def get(elastic_url, name) do
-    prepare_url(elastic_url, name)
-    |> HTTP.get()
+  @spec get(binary, binary) :: HTTP.resp
+  def get(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, index)
+    HTTP.get(url)
   end
 
   @doc """
-  Returns `true` if the specified index exists, `false` otherwise.
+  Check if index exists.
+
+  Returns `{:ok, true}` if the index exists.
 
   ## Examples
 
       iex> Elastix.Index.exists?("http://localhost:9200", "twitter")
       {:ok, false}
+
       iex> Elastix.Index.create("http://localhost:9200", "twitter", %{})
       {:ok, %HTTPoison.Response{...}}
+
       iex> Elastix.Index.exists?("http://localhost:9200", "twitter")
       {:ok, true}
-  """
-  @spec exists?(elastic_url :: String.t(), name :: String.t()) ::
-          {:ok, boolean()} | {:error, HTTPoison.Error.t()}
-  def exists?(elastic_url, name) do
-    case prepare_url(elastic_url, name) |> HTTP.head() do
-      {:ok, response} ->
-        case response.status_code do
-          200 -> {:ok, true}
-          404 -> {:ok, false}
-        end
 
-      err ->
-        err
+  """
+  @spec exists?(binary, binary) :: {:ok, boolean} | {:error, HTTPoison.Error.t}
+  def exists?(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, index)
+    case HTTP.head(url) do
+      {:ok, %{status_code: 200}} -> {:ok, true}
+      {:ok, %{status_code: 404}} -> {:ok, false}
+      err -> err
     end
   end
 
   @doc """
-  Forces the [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html)
-  of the specified index.
+  Force refresh of index.
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html)
 
   ## Examples
 
       iex> Elastix.Index.refresh("http://localhost:9200", "twitter")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec refresh(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
-  def refresh(elastic_url, name) do
-    prepare_url(elastic_url, [name, "_refresh"])
-    |> HTTP.post("")
+  @spec refresh(binary, binary) :: HTTP.resp
+  def refresh(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, [index, "_refresh"])
+    HTTP.post(url, "")
   end
 
   @doc """
-  [Opens](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)
-  the specified index.
+  Open index.
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)
 
   ## Examples
 
       iex> Elastix.Index.open("http://localhost:9200", "twitter")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec open(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
-  def open(elastic_url, name) do
-    prepare_url(elastic_url, [name, "_open"])
-    |> HTTP.post("")
+  @spec open(binary, binary) :: HTTP.resp
+  def open(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, [index, "_open"])
+    HTTP.post(url, "")
   end
 
   @doc """
-  [Closes](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)
-  the specified index.
+  Close index.
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)
 
   ## Examples
 
       iex> Elastix.Index.close("http://localhost:9200", "twitter")
       {:ok, %HTTPoison.Response{...}}
+
   """
-  @spec close(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
-  def close(elastic_url, name) do
-    prepare_url(elastic_url, [name, "_close"])
-    |> HTTP.post("")
+  @spec close(binary, binary) :: HTTP.resp
+  def close(elastic_url, index) do
+    url = HTTP.make_url(elastic_url, [index, "_close"])
+    HTTP.post(url, "")
   end
 end

--- a/lib/elastix/json.ex
+++ b/lib/elastix/json.ex
@@ -1,4 +1,7 @@
 defmodule Elastix.JSON do
+
+  require Logger
+
   defmodule Codec do
     @moduledoc """
     A behaviour for JSON serialization.
@@ -53,7 +56,7 @@ defmodule Elastix.JSON do
         Elastix.config(:json_options, [])
 
       opts ->
-        IO.warn(
+        Logger.warn(
           "Using :poison_options is deprecated and might not work in future releases; use :json_options instead."
         )
 

--- a/lib/elastix/snapshot/repository.ex
+++ b/lib/elastix/snapshot/repository.ex
@@ -1,76 +1,257 @@
 defmodule Elastix.Snapshot.Repository do
   @moduledoc """
-  Functions for working with repositories. A repository is required for taking and restoring snapshots of indices.
+  Functions for working with repositories.
+
+  A repository is a location used to store snapshots when
+  backing up and restoring data in an Elasticsearch cluster.
 
   [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
   """
 
-  import Elastix.HTTP, only: [prepare_url: 2]
   alias Elastix.{HTTP, JSON}
 
   @doc """
-  Registers a repository.
+  Register repository.
+
+  It's necessary to register a snapshot repository before performing
+  snapshot and restore operations.
+
+  ## Examples
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix_test_repository_1"
+      iex> config = %{type: "fs", settings: %{location: "/tmp/elastix/backups"}}
+      iex> Elastix.Repository.register(elastic_url, repository, config)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{"acknowledged" => true},
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "21"}],
+          request: %HTTPoison.Request{
+            body: "{\"type\":\"fs\",\"settings\":{\"location\":\"/tmp/elastix/backups\"}}",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :put,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1",
+          status_code: 200
+        }
+      }
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix_test_repository_2"
+      iex> config = %{type: "fs", settings: %{location: "/tmp/elastix/backups"}}
+      iex> Elastix.Repository.register(elastic_url, repository, config, verify: false)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{"acknowledged" => true},
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "21"}],
+          request: %HTTPoison.Request{
+            body: "{\"type\":\"fs\",\"settings\":{\"location\":\"/tmp/elastix/backups\"}}",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :put,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_2?verify=false"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_2?verify=false",
+          status_code: 200
+        }
+      }
+
   """
-  @spec register(String.t(), String.t(), Map.t(), [tuple()]) ::
-          {:ok, %HTTPoison.Response{}}
-  def register(elastic_url, repo_name, data, query_params \\ []) do
-    elastic_url
-    |> prepare_url(make_path(repo_name, query_params))
-    |> HTTP.put(JSON.encode!(data))
+  @spec register(binary, binary, map, Keyword.t) :: HTTP.resp
+  def register(elastic_url, repo, config, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, make_path(repo), query_params)
+    HTTP.put(url, JSON.encode!(config))
   end
 
   @doc """
-  Verifies a registered but unverified repository.
+  Verify repository.
+
+  Verify a repository which was initially registered without verification,
+  (`verify: false`).
+
+  Returns list of nodes where repository was successfully verified or an error
+  message if verification failed.
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repository_verification)
+
+  ## Examples
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix_test_repository"
+      iex> Elastix.Repository.verify(elastic_url, repository)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{"nodes" => %{"O5twn2YcS0GvFPra5lllUQ" => %{"name" => "O5twn2Y"}}},
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "55"}],
+          request: %HTTPoison.Request{
+            body: "",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :post,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_2/_verify"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_2/_verify",
+          status_code: 200
+        }
+      }
+
   """
-  @spec verify(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
-  def verify(elastic_url, repo_name) do
-    elastic_url
-    |> prepare_url([make_path(repo_name), "_verify"])
-    |> HTTP.post("")
+  @spec verify(binary, binary) :: HTTP.resp
+  def verify(elastic_url, repo) do
+    url = HTTP.make_url(elastic_url, [make_path(repo), "_verify"])
+    HTTP.post(url, "")
   end
 
   @doc """
-  If repo_name specified, will retrieve information about a registered repository.
-  Otherwise, will retrieve information about all repositories.
+  Get info about repositories.
+
+  Gets info about all repositories, or a single repo if specified.
+
+  ## Examples
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> Elastix.Repository.get(elastic_url)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{
+            "elastix_test_repository_1" => %{"settings" => %{"location" => "/tmp/elastix/backups"}, "type" => "fs"},
+            "elastix_test_repository_2" => %{"settings" => %{"location" => "/tmp/elastix/backups"}, "type" => "fs"}
+          },
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "179"}],
+          request: %HTTPoison.Request{
+            body: "",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :get,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/_all"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/_all",
+          status_code: 200
+        }
+      }
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix_test_repository_1"
+      iex> Elastix.Repository.get(elastic_url, repository)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{"elastix_test_repository_1" => %{"settings" => %{"location" => "/tmp/elastix/backups"}, "type" => "fs"}},
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "90"}],
+          request: %HTTPoison.Request{
+            body: "",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :get,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1",
+          status_code: 200
+        }
+      }
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix*"
+      iex> Elastix.Repository.get(elastic_url, repository)
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "foo,bar"
+      iex> Elastix.Repository.get(elastic_url, repository)
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "nonexistent"
+      iex> Elastix.Repository.get(elastic_url, repository)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{
+            "error" => %{
+              "reason" => "[nonexistent] missing",
+              "root_cause" => [%{"reason" => "[nonexistent] missing", "type" => "repository_missing_exception"}],
+              "type" => "repository_missing_exception"
+            },
+            "status" => 404
+          },
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "183"}],
+          request: %HTTPoison.Request{
+            body: "",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :get,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/nonexistent"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/nonexistent",
+          status_code: 404
+        }
+      }
+
+
   """
-  @spec get(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
-  def get(elastic_url, repo_name \\ "_all") do
-    elastic_url
-    |> prepare_url(make_path(repo_name))
-    |> HTTP.get()
+  @spec get(binary, binary) :: HTTP.resp
+  def get(elastic_url, repo \\ "_all") do
+    url = HTTP.make_url(elastic_url, make_path(repo))
+    HTTP.get(url)
+  end
+
+
+  @doc """
+  Remove reference to location where snapshots are stored.
+
+  ## Examples
+
+      iex> elastic_url = "http://localhost:9200"
+      iex> repository = "elastix_test_repository_1"
+      iex> Elastix.Repository.get(elastic_url, repository)
+      {:ok,
+        %HTTPoison.Response{
+          body: %{"acknowledged" => true},
+          headers: [{"content-type", "application/json; charset=UTF-8"}, {"content-length", "21"}],
+          request: %HTTPoison.Request{
+            body: "",
+            headers: [{"Content-Type", "application/json; charset=UTF-8"}],
+            method: :delete,
+            options: [],
+            params: %{},
+            url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1"
+          },
+          request_url: "http://127.0.0.1:9200/_snapshot/elastix_test_repository_1",
+          status_code: 200
+        }
+      }
+
+  """
+  @spec delete(binary, binary) :: HTTP.resp
+  def delete(elastic_url, repo) do
+    url = HTTP.make_url(elastic_url, make_path(repo))
+    HTTP.delete(url)
   end
 
   @doc """
-  Removes the reference to the location where the snapshots are stored.
+  Clean up unreferenced data in a repository.
+
+  Trigger a complete accounting of the repositories contents and subsequent
+  deletion of all unreferenced data that was found.
+
+  Deleting a snapshot performs this cleanup.
+
+  Available in Elasticsearch 7.x and later.
   """
-  @spec delete(String.t(), String.t()) :: {:ok, %HTTPoison.Response{}}
-  def delete(elastic_url, repo_name) do
-    elastic_url
-    |> prepare_url(make_path(repo_name))
-    |> HTTP.delete()
+  @spec cleanup(binary, binary) :: HTTP.resp
+  def cleanup(elastic_url, repo) do
+    url = HTTP.make_url(elastic_url, [make_path(repo), "_cleanup"])
+    HTTP.post(url, "")
   end
 
   @doc false
-  @spec make_path(String.t(), [tuple()]) :: String.t()
-  def make_path(repo_name, query_params \\ []) do
-    path = _make_base_path(repo_name)
+  # Make path from arguments
+  @spec make_path(binary | nil) :: binary
+  def make_path(nil), do: "/_snapshot"
+  def make_path(repo), do: "/_snapshot/#{repo}"
 
-    case query_params do
-      [] -> path
-      _ -> _add_query_params(path, query_params)
-    end
-  end
-
-  defp _make_base_path(nil), do: "/_snapshot"
-  defp _make_base_path(repo_name), do: "/_snapshot/#{repo_name}"
-
-  defp _add_query_params(path, query_params) do
-    query_string =
-      query_params
-      |> Enum.map_join("&", fn param ->
-        "#{elem(param, 0)}=#{elem(param, 1)}"
-      end)
-
-    "#{path}?#{query_string}"
-  end
 end

--- a/lib/elastix/template.ex
+++ b/lib/elastix/template.ex
@@ -1,0 +1,131 @@
+defmodule Elastix.Template do
+  @moduledoc """
+  Index templates define settings and mappings that you can automatically apply
+  when creating new indices. Elasticsearch applies templates to new indices
+  based on an index pattern that matches the index name.
+
+  [Elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html)
+  """
+  alias Elastix.{HTTP, JSON}
+
+  @doc """
+  Create a new index template.
+
+  ## Examples
+
+      iex> template = %{
+         "index_patterns" => "logstash-*",
+         "mappings" => %{
+           "dynamic_templates" => [
+             %{
+               "message_field" => %{
+                 "mapping" => %{"norms" => false, "type" => "text"},
+                 "match_mapping_type" => "string",
+                 "path_match" => "message"
+               }
+             },
+             %{
+               "string_fields" => %{
+                 "mapping" => %{
+                   "fields" => %{
+                     "keyword" => %{"ignore_above" => 256, "type" => "keyword"}
+                   },
+                   "norms" => false,
+                   "type" => "text"
+                 },
+                 "match" => "*",
+                 "match_mapping_type" => "string"
+               }
+             }
+           ],
+           "properties" => %{
+             "@timestamp" => %{"type" => "date"},
+             "@version" => %{"type" => "keyword"},
+             "geoip" => %{
+               "dynamic" => true,
+               "properties" => %{
+                 "ip" => %{"type" => "ip"},
+                 "latitude" => %{"type" => "half_float"},
+                 "location" => %{"type" => "geo_point"},
+                 "longitude" => %{"type" => "half_float"}
+               }
+             }
+           }
+         },
+         "settings" => %{"index.refresh_interval" => "5s", "number_of_shards" => 1},
+         "version" => 60001
+       }
+      iex> Elastix.Template.put("http://localhost:9200", "logstash", template)
+      {:ok, %HTTPoison.Response{...}}
+  """
+  @spec put(binary, binary, binary | term, Keyword.t) :: HTTP.resp
+  def put(elastic_url, template, data, query_params \\ [])
+  def put(elastic_url, template, data, query_params) when is_binary(data) do
+    url = HTTP.make_url(elastic_url, make_path(template), query_params)
+    HTTP.put(url, data)
+  end
+  def put(elastic_url, template, data, query_params) do
+    put(elastic_url, template, JSON.encode!(data), query_params)
+  end
+
+  @doc """
+  Determine if an index template has alreay been registered.
+
+  ## Examples
+
+      iex> Elastix.Template.exists?("http://localhost:9200", "logstash")
+      {:ok, false}
+
+      iex> Elastix.Template.exists?("http://localhost:9200", "logstash")
+      {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}
+  """
+  @spec exists?(binary, binary, Keyword.t) :: {:ok, boolean} | {:error, HTTPoison.Error.t}
+  def exists?(elastic_url, template, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, make_path(template), query_params)
+
+    case HTTP.head(url) do
+      {:ok, %{status_code: code}} when code >= 200 and code <= 299 ->
+        {:ok, true}
+      {:ok, _} ->
+        {:ok, false}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Get info on an index template.
+
+  ## Examples
+
+      iex> Elastix.Template.get("http://localhost:9200", "logstash")
+      {:ok, %HTTPoison.Response{...}}
+  """
+  @spec get(binary, binary, Keyword.t) :: HTTP.resp
+  def get(elastic_url, template, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, make_path(template), query_params)
+    HTTP.get(url)
+  end
+
+  @doc """
+  Delete an index template.
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-template.html)
+  #
+  ## Examples
+
+      iex> Elastix.Template.get("http://localhost:9200", "logstash")
+      {:ok, %HTTPoison.Response{...}}
+  """
+  @spec delete(binary, binary, Keyword.t) :: HTTP.resp
+  def delete(elastic_url, template, query_params \\ []) do
+    url = HTTP.make_url(elastic_url, make_path(template), query_params)
+    HTTP.delete(url)
+  end
+
+  @doc false
+  # Convert params into path
+  @spec make_path(binary) :: binary
+  def make_path(template), do: "/_template/#{template}"
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,15 @@ defmodule Elastix.Mixfile do
       aliases: aliases(),
       deps: deps(),
       name: "Elastix",
-      docs: docs()
+      docs: docs(),
+      dialyzer: [
+        # plt_add_deps: :project,
+        # plt_add_apps: [:ssl, :mnesia, :compiler, :xmerl, :inets],
+        # plt_add_deps: true,
+        # flags: ["-Werror_handling", "-Wrace_conditions"],
+        # flags: ["-Wunmatched_returns", :error_handling, :race_conditions, :underspecs],
+        # ignore_warnings: "dialyzer.ignore-warnings"
+      ],
     ]
   end
 
@@ -39,6 +47,7 @@ defmodule Elastix.Mixfile do
     [
       {:ex_doc, "~> 0.14", only: :dev},
       {:credo, "~> 0.6", only: [:dev, :test]},
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       {:mix_test_watch, "~> 0.3", only: [:test, :dev]},
       {:poison, "~> 4.0", optional: true},
       {:httpoison, "~> 1.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "credo": {:hex, :credo, "0.9.0", "5d1b494e4f2dc672b8318e027bd833dda69be71eaac6eedd994678be74ef7cb4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},

--- a/test/elastix/bulk_test.exs
+++ b/test/elastix/bulk_test.exs
@@ -4,6 +4,8 @@ defmodule Elastix.BulkTest do
   alias Elastix.Bulk
   alias Elastix.Document
 
+  import ExUnit.CaptureLog
+
   @test_url Elastix.config(:test_url)
   @test_index Elastix.config(:test_index)
 
@@ -13,18 +15,18 @@ defmodule Elastix.BulkTest do
     :ok
   end
 
-  test "make_path should make url from index name, type, and query params" do
-    assert Bulk.make_path(@test_index, "tweet", version: 34, ttl: "1d") ==
-             "/#{@test_index}/tweet/_bulk?version=34&ttl=1d"
-  end
+  describe "make_path/2" do
+    test "makes path from index name and type" do
+      assert Bulk.make_path(@test_index, "tweet") == "/#{@test_index}/tweet/_bulk"
+    end
 
-  test "make_path should make url from index name and query params" do
-    assert Bulk.make_path(@test_index, nil, version: 34, ttl: "1d") ==
-             "/#{@test_index}/_bulk?version=34&ttl=1d"
-  end
+    test "makes path from index name" do
+      assert Bulk.make_path(@test_index, nil) == "/#{@test_index}/_bulk"
+    end
 
-  test "make_path should make url from query params" do
-    assert Bulk.make_path(nil, nil, version: 34, ttl: "1d") == "/_bulk?version=34&ttl=1d"
+    test "makes path with default" do
+      assert Bulk.make_path(nil, nil) == "/_bulk"
+    end
   end
 
   test "bulk accepts httpoison options" do
@@ -49,47 +51,37 @@ defmodule Elastix.BulkTest do
        ]}
     end
 
-    test "post bulk should execute it", %{lines: lines} do
+    test "post bulk", %{lines: lines} do
       {:ok, response} = Bulk.post(@test_url, lines, index: @test_index, type: "message")
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
-    test "post bulk with raw body should execute it", %{lines: lines} do
-      {:ok, response} =
-        Bulk.post_raw(
-          @test_url,
-          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end),
-          index: @test_index,
-          type: "message"
-        )
-
+    test "post bulk with raw body", %{lines: lines} do
+      encoded = Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+      {:ok, response} = Bulk.post_raw(@test_url, encoded, index: @test_index, type: "message")
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
+    test "post_to_iolist/4 should log deprecation warning", %{lines: lines} do
+      assert capture_log(fn ->
+        Bulk.post_to_iolist(@test_url, lines, index: @test_index, type: "message")
+      end) =~ "This function is deprecated and will be removed in future releases; use Elastix.Bulk.post/4 instead"
+    end
+
+    @tag capture_log: true
     test "post bulk sending iolist should execute it", %{lines: lines} do
       {:ok, response} =
         Bulk.post_to_iolist(@test_url, lines, index: @test_index, type: "message")
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 
@@ -106,43 +98,28 @@ defmodule Elastix.BulkTest do
 
     test "post bulk should execute it", %{lines: lines} do
       {:ok, response} = Bulk.post(@test_url, lines, index: @test_index)
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk with raw body should execute it", %{lines: lines} do
-      {:ok, response} =
-        Bulk.post_raw(
-          @test_url,
-          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end),
-          index: @test_index
-        )
-
+      encoded = Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+      {:ok, response} = Bulk.post_raw(@test_url, encoded, index: @test_index)
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
+    @tag capture_log: true
     test "post bulk sending iolist should execute it", %{lines: lines} do
       {:ok, response} = Bulk.post_to_iolist(@test_url, lines, index: @test_index)
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 
@@ -159,42 +136,28 @@ defmodule Elastix.BulkTest do
 
     test "post bulk should execute it", %{lines: lines} do
       {:ok, response} = Bulk.post(@test_url, lines)
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
     test "post bulk with raw body should execute it", %{lines: lines} do
-      {:ok, response} =
-        Bulk.post_raw(
-          @test_url,
-          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
-        )
-
+      encoded = Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+      {:ok, response} = Bulk.post_raw(@test_url, encoded)
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
 
+    @tag capture_log: true
     test "post bulk sending iolist should execute it", %{lines: lines} do
       {:ok, response} = Bulk.post_to_iolist(@test_url, lines)
-
       assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "1")
-
-      assert {:ok, %{status_code: 200}} =
-               Document.get(@test_url, @test_index, "message", "2")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "1")
+      assert {:ok, %{status_code: 200}} = Document.get(@test_url, @test_index, "message", "2")
     end
   end
 end

--- a/test/elastix/document_test.exs
+++ b/test/elastix/document_test.exs
@@ -2,6 +2,7 @@ defmodule Elastix.DocumentTest do
   require Logger
   use ExUnit.Case
   alias Elastix.{Document, Index, Search}
+  alias Elastix.HTTP
 
   @test_url Elastix.config(:test_url)
   @test_index Elastix.config(:test_index)
@@ -11,100 +12,190 @@ defmodule Elastix.DocumentTest do
     message: "trying out Elasticsearch"
   }
 
+  setup_all do
+    # Query the Elasticsearch instance to determine what version it is running
+    # so we can use it in tests.
+    {:ok, response} = HTTP.get(@test_url)
+    {version, _rest} = Float.parse(response.body["version"]["number"])
+
+    {:ok, version: version}
+  end
+
+
   setup do
     Index.delete(@test_url, @test_index)
 
     :ok
   end
 
-  test "make_path should make url from index name, type, query params, id, and suffix" do
-    assert Document.make_path(
-             @test_index,
-             "tweet",
-             [version: 34, ttl: "1d"],
-             2,
-             "_update"
-           ) == "/#{@test_index}/tweet/2/_update?version=34&ttl=1d"
+  describe "make_path/5" do
+    test "makes path from index name, type, query params, id, and suffix" do
+      assert Document.make_path_old(@test_index, "tweet", [version: 34, ttl: "1d"], 2, "_update") ==
+        "/#{@test_index}/tweet/2/_update?version=34&ttl=1d"
+    end
+
+    test "makes path from index name, type, and query params" do
+      assert Document.make_path_old(@test_index, "tweet", version: 34, ttl: "1d") ==
+        "/#{@test_index}/tweet?version=34&ttl=1d"
+    end
   end
 
-  test "make_path without and id should make url from index name, type, and query params" do
-    assert Document.make_path(@test_index, "tweet", version: 34, ttl: "1d") ==
-             "/#{@test_index}/tweet?version=34&ttl=1d"
+  describe "make_path/2" do
+    test "handles all options" do
+      assert Document.make_path(@test_index, %{id: 42}) == "/#{@test_index}/_doc/42"
+      assert Document.make_path(@test_index) == "/#{@test_index}/_doc/"
+    end
   end
 
-  test "index should create and index with data" do
-    {:ok, response} = Document.index(@test_url, @test_index, "message", 1, @data)
+  describe "index/6" do
+    test "old API indexes document", %{version: version} do
+      {:ok, response} = Document.index(@test_url, @test_index, "message", 1, @data)
 
-    assert response.status_code == 201
-    assert response.body["_id"] == "1"
-    assert response.body["_index"] == @test_index
-    assert response.body["_type"] == "message"
-    assert response.body["created"] == true
+      assert response.status_code == 201
+      assert response.body["_id"] == "1"
+      assert response.body["_index"] == @test_index
+      assert response.body["_type"] == "message"
+      if version >= 6.0 do
+        assert response.body["result"] == "created"
+      else
+        assert response.body["created"] == true
+      end
+    end
+
+    test "new API indexes document" do
+      {:ok, response} = Document.index(@test_url, @test_index, @data, %{id: 1})
+      assert response.status_code == 201
+      assert response.body["_id"] == "1"
+      assert response.body["_index"] == @test_index
+      assert response.body["result"] == "created"
+    end
+
   end
 
-  test "index_new should index data without an id" do
+  test "index_new should index data without an id", %{version: version} do
     {:ok, response} = Document.index_new(@test_url, @test_index, "message", @data)
 
     assert response.status_code == 201
     assert response.body["_id"]
     assert response.body["_index"] == @test_index
     assert response.body["_type"] == "message"
-    assert response.body["created"] == true
+    if version >= 6.0 do
+      assert response.body["result"] == "created"
+    else
+      assert response.body["created"] == true
+    end
   end
 
-  test "get should return 404 if not index was created" do
-    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+  describe "get/5 old API" do
+    test "get returns 404 on unknown index" do
+      {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+      assert response.status_code == 404
+    end
 
-    assert response.status_code == 404
+    test "get returns data with 200 after index" do
+      Document.index(@test_url, @test_index, "message", 1, @data)
+      {:ok, %{status_code: 200, body: body}} = Document.get(@test_url, @test_index, "message", 1)
+
+      assert body["_source"]["user"] == "örelbörel"
+      assert body["_source"]["post_date"] == "2009-11-15T14:12:12"
+      assert body["_source"]["message"] == "trying out Elasticsearch"
+    end
   end
 
-  test "get should return data with 200 after index" do
-    Document.index(@test_url, @test_index, "message", 1, @data)
-    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
-    body = response.body
+  describe "get/5 new API" do
+    test "get returns 404 on unknown index" do
+      {:ok, response} = Document.get(@test_url, @test_index, 1)
+      assert response.status_code == 404
+    end
 
-    assert response.status_code == 200
-    assert body["_source"]["user"] == "örelbörel"
-    assert body["_source"]["post_date"] == "2009-11-15T14:12:12"
-    assert body["_source"]["message"] == "trying out Elasticsearch"
+    test "get returns data with 200 after index" do
+      {:ok, %{status_code: 201}} = Document.index(@test_url, @test_index, @data, %{id: 1})
+      {:ok, %{status_code: 200, body: body}} = Document.get(@test_url, @test_index, 1)
+
+      assert body["_source"]["user"] == "örelbörel"
+      assert body["_source"]["post_date"] == "2009-11-15T14:12:12"
+      assert body["_source"]["message"] == "trying out Elasticsearch"
+    end
   end
 
-  test "delete should delete created index" do
-    Document.index(@test_url, @test_index, "message", 1, @data)
+  describe "delete/5 old API" do
 
-    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
-    assert response.status_code == 200
+    test "delete should delete created index" do
+      Document.index(@test_url, @test_index, "message", 1, @data)
 
-    {:ok, response} = Document.delete(@test_url, @test_index, "message", 1)
-    assert response.status_code == 200
+      {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+      assert response.status_code == 200
 
-    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
-    assert response.status_code == 404
+      {:ok, response} = Document.delete(@test_url, @test_index, "message", 1)
+      assert response.status_code == 200
+
+      {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+      assert response.status_code == 404
+    end
+
+    test "delete by query should remove all docs that match" do
+      Document.index(@test_url, @test_index, "message", 1, @data, refresh: true)
+      Document.index(@test_url, @test_index, "message", 2, @data, refresh: true)
+
+      no_match = Map.put(@data, :user, "no match")
+      Document.index(@test_url, @test_index, "message", 3, no_match, refresh: true)
+
+      match_all_query = %{"query" => %{"match_all" => %{}}}
+
+      {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
+      assert response.status_code == 200
+      assert response.body["hits"]["total"] == 3
+
+      query = %{"query" => %{"match" => %{"user" => "örelbörel"}}}
+
+      {:ok, response} =
+        Document.delete_matching(@test_url, @test_index, query, refresh: true)
+
+      assert response.status_code == 200
+
+      {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
+      assert response.status_code == 200
+      assert response.body["hits"]["total"] == 1
+    end
   end
 
-  test "delete by query should remove all docs that match" do
-    Document.index(@test_url, @test_index, "message", 1, @data, refresh: true)
-    Document.index(@test_url, @test_index, "message", 2, @data, refresh: true)
+  describe "delete/5 new API" do
 
-    no_match = Map.put(@data, :user, "no match")
-    Document.index(@test_url, @test_index, "message", 3, no_match, refresh: true)
+    test "deletes created index" do
+      Document.index(@test_url, @test_index, @data, %{id: 1})
 
-    match_all_query = %{"query" => %{"match_all" => %{}}}
+      {:ok, response} = Document.get(@test_url, @test_index, 1)
+      assert response.status_code == 200
 
-    {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
-    assert response.status_code == 200
-    assert response.body["hits"]["total"] == 3
+      {:ok, response} = Document.delete(@test_url, @test_index, 1)
+      assert response.status_code == 200
 
-    query = %{"query" => %{"match" => %{"user" => "örelbörel"}}}
+      {:ok, response} = Document.get(@test_url, @test_index, 1)
+      assert response.status_code == 404
+    end
 
-    {:ok, response} =
-      Document.delete_matching(@test_url, @test_index, query, refresh: true)
+    test "delete by query should remove all docs that match" do
+      Document.index(@test_url, @test_index, @data, %{id: 1}, refresh: true)
+      Document.index(@test_url, @test_index, @data, %{id: 2}, refresh: true)
 
-    assert response.status_code == 200
+      no_match = Map.put(@data, :user, "no match")
+      Document.index(@test_url, @test_index, no_match, %{id: 3}, refresh: true)
 
-    {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
-    assert response.status_code == 200
-    assert response.body["hits"]["total"] == 1
+      match_all_query = %{"query" => %{"match_all" => %{}}}
+
+      {:ok, response} = Search.search(@test_url, @test_index, [], match_all_query)
+      assert response.status_code == 200
+      assert response.body["hits"]["total"] == 3
+
+      query = %{"query" => %{"match" => %{"user" => "örelbörel"}}}
+
+      {:ok, response} = Document.delete_matching(@test_url, @test_index, query, refresh: true)
+      assert response.status_code == 200
+
+      {:ok, response} = Search.search(@test_url, @test_index, [], match_all_query)
+      assert response.status_code == 200
+      assert response.body["hits"]["total"] == 1
+    end
   end
 
   test "update can partially update document" do
@@ -125,74 +216,114 @@ defmodule Elastix.DocumentTest do
     assert body["_source"]["message"] == "trying out Elasticsearch"
   end
 
-  test "can get multiple documents (multi get)" do
-    Document.index(@test_url, @test_index, "message", 1, @data)
-    Document.index(@test_url, @test_index, "message", 2, @data)
+  describe "mget/5 old API" do
 
-    query = %{
-      "docs" => [
-        %{
-          "_index" => @test_index,
-          "_type" => "message",
-          "_id" => "1"
-        },
-        %{
-          "_index" => @test_index,
-          "_type" => "message",
-          "_id" => "2"
-        }
-      ]
-    }
+    test "can get multiple documents (multi get)" do
+      Document.index(@test_url, @test_index, "message", 1, @data)
+      Document.index(@test_url, @test_index, "message", 2, @data)
 
-    {:ok, %{body: body, status_code: status_code}} = Document.mget(@test_url, query)
+      query = %{
+        "docs" => [
+          %{"_index" => @test_index, "_type" => "message", "_id" => "1"},
+          %{"_index" => @test_index,
+            "_type" => "message",
+            "_id" => "2"
+          }
+        ]
+      }
 
-    assert status_code === 200
-    assert length(body["docs"]) == 2
+      {:ok, %{body: body, status_code: status_code}} = Document.mget(@test_url, query)
+
+      assert status_code === 200
+      assert length(body["docs"]) == 2
+    end
+
+    test "can get multiple documents (multi get with index)" do
+      Document.index(@test_url, @test_index, "message", 1, @data)
+      Document.index(@test_url, @test_index, "message", 2, @data)
+
+      query = %{
+        "docs" => [
+          %{"_type" => "message", "_id" => "1"},
+          %{"_type" => "message", "_id" => "2"}
+        ]
+      }
+
+      {:ok, %{body: body, status_code: status_code}} =
+        Document.mget(@test_url, query, @test_index)
+
+      assert status_code === 200
+      assert length(body["docs"]) == 2
+    end
+
+    test "can get multiple documents (multi get with index and type)" do
+      Document.index(@test_url, @test_index, "message", 1, @data)
+      Document.index(@test_url, @test_index, "message", 2, @data)
+
+      query = %{
+        "docs" => [
+          %{"_id" => "1"},
+          %{"_id" => "2"}
+        ]
+      }
+
+      {:ok, %{body: body, status_code: status_code}} =
+        Document.mget(@test_url, query, @test_index, "message")
+
+      assert status_code === 200
+      assert length(body["docs"]) == 2
+    end
   end
 
-  test "can get multiple documents (multi get with index)" do
-    Document.index(@test_url, @test_index, "message", 1, @data)
-    Document.index(@test_url, @test_index, "message", 2, @data)
+  describe "mget/5 new API" do
+    test "can get multiple documents (multi get)" do
+      Document.index(@test_url, @test_index, @data, %{id: 1})
+      Document.index(@test_url, @test_index, @data, %{id: 2})
 
-    query = %{
-      "docs" => [
-        %{
-          "_type" => "message",
-          "_id" => "1"
-        },
-        %{
-          "_type" => "message",
-          "_id" => "2"
-        }
-      ]
-    }
+      query = %{
+        "docs" => [
+          %{"_index" => @test_index, "_id" => "1"},
+          %{"_index" => @test_index, "_id" => "2"}
+        ]
+      }
 
-    {:ok, %{body: body, status_code: status_code}} =
-      Document.mget(@test_url, query, @test_index)
+      {:ok, %{body: body, status_code: status_code}} = Document.mget(@test_url, query)
 
-    assert status_code === 200
-    assert length(body["docs"]) == 2
+      assert status_code === 200
+      assert length(body["docs"]) == 2
+    end
+
+    test "can get multiple documents (multi get with index)" do
+      Document.index(@test_url, @test_index, @data, %{id: 1})
+      Document.index(@test_url, @test_index, @data, %{id: 2})
+
+      query = %{
+        "docs" => [
+          %{"_id" => "1"},
+          %{"_id" => "2"}
+        ]
+      }
+
+      {:ok, response} = Document.mget(@test_url, query, @test_index)
+      assert response.status_code === 200
+      assert length(response.body["docs"]) == 2
+    end
+
+    test "can get multiple documents" do
+      Document.index(@test_url, @test_index, @data, %{id: 1})
+      Document.index(@test_url, @test_index, @data, %{id: 2})
+
+      query = %{
+        "docs" => [
+          %{"_id" => "1"},
+          %{"_id" => "2"}
+        ]
+      }
+
+      {:ok, response} = Document.mget(@test_url, query, @test_index)
+      assert response.status_code == 200
+      assert length(response.body["docs"]) == 2
+    end
   end
 
-  test "can get multiple documents (multi get with index and type)" do
-    Document.index(@test_url, @test_index, "message", 1, @data)
-    Document.index(@test_url, @test_index, "message", 2, @data)
-
-    query = %{
-      "docs" => [
-        %{
-          "_id" => "1"
-        },
-        %{
-          "_id" => "2"
-        }
-      ]
-    }
-
-    {:ok, %{body: body, status_code: status_code}} =
-      Document.mget(@test_url, query, @test_index, "message")
-
-    assert status_code === 200
-    assert length(body["docs"]) == 2
-  end
 end

--- a/test/elastix/http_test.exs
+++ b/test/elastix/http_test.exs
@@ -1,32 +1,60 @@
 defmodule Elastix.HTTPTest do
+  @app :elastix
+
   use ExUnit.Case
+  import ExUnit.CaptureLog
+
   alias Elastix.HTTP
 
-  @test_url Elastix.config(:test_url)
+  @test_url Application.get_env(@app, :test_url)
 
-  test "prepare_url/2 should concat url with path" do
-    assert HTTP.prepare_url("http://127.0.0.1:9200/", "/some_path") ==
-             "http://127.0.0.1:9200/some_path"
-  end
+  setup_all do
+    # Query the Elasticsearch instance to determine what version it is running
+    # so we can use it in tests.
+    {:ok, response} = HTTP.get(@test_url)
+    {version, _rest} = Float.parse(response.body["version"]["number"])
 
-  test "prepare_url/2 should concat url with a list of path parts" do
-    assert HTTP.prepare_url("http://127.0.0.1:9200/", ["/some/", "/path/"]) ==
-             "http://127.0.0.1:9200/some/path"
+    {:ok, version: version}
   end
 
   test "get should respond with 200" do
-    {_, response} = HTTP.get(@test_url, [])
+    {:ok, response} = HTTP.get(@test_url, [])
     assert response.status_code == 200
   end
 
-  test "post should respond with 400" do
-    {_, response} = HTTP.post(@test_url, [])
-    assert response.status_code == 400
+  test "make_url/3 handles all options" do
+    url = "http://localhost:9200"
+    assert HTTP.make_url(url, "foo") == "#{url}/foo"
+    assert HTTP.make_url(url, ["foo", "bar"]) == "#{url}/foo/bar"
+    assert HTTP.make_url(url, "/foo") == "#{url}/foo"
+    assert HTTP.make_url(url, "/foo", this: true) == "#{url}/foo?this=true"
+    assert HTTP.make_url(url, "/foo", %{biz: :baz, hello: 1}) == "#{url}/foo?biz=baz&hello=1"
   end
 
-  test "put should respond with 400" do
+  test "add_content_type_header/1" do
+    default_headers = [{"Content-Type", "application/json; charset=UTF-8"}]
+    bulk_headers = [{"Content-Type", "application/x-ndjson"}]
+
+    assert HTTP.add_content_type_header([]) == default_headers
+    assert HTTP.add_content_type_header(bulk_headers) == bulk_headers
+  end
+
+  test "post should respond with 400", %{version: version} do
+    {_, response} = HTTP.post(@test_url, [])
+    if version >= 6.0 do
+      assert response.status_code == 405
+    else
+      assert response.status_code == 400
+    end
+  end
+
+  test "put should respond with 400", %{version: version} do
     {_, response} = HTTP.put(@test_url, [])
-    assert response.status_code == 400
+    if version >= 6.0 do
+      assert response.status_code == 405
+    else
+      assert response.status_code == 400
+    end
   end
 
   test "delete should respond with 400" do
@@ -44,11 +72,34 @@ defmodule Elastix.HTTPTest do
     assert HTTP.process_response_body(body) == body
   end
 
-  test "process_response_body parsed the body into an atom key map if configured" do
-    body = "{\"some\":\"json\"}"
-    Application.put_env(:elastix, :poison_options, keys: :atoms)
-    assert HTTP.process_response_body(body) == %{some: "json"}
-    Application.delete_env(:elastix, :poison_options)
+  describe "Environment specific tests" do
+    setup do
+      Application.put_env(:elastix, :poison_options, keys: :atoms)
+      Application.put_env(:elastix, :json_options, keys: :atoms)
+
+      on_exit(fn ->
+        Application.delete_env(:elastix, :poison_options)
+        Application.delete_env(:elastix, :json_options)
+      end)
+
+      :ok
+    end
+
+    test "using :poison_options logs a deprecation warning" do
+      assert capture_log(fn ->
+        body = "{\"some\":\"json\"}"
+        Application.put_env(:elastix, :poison_options, keys: :atoms)
+        %{some: "json"} = HTTP.process_response_body(body)
+      end) =~ "Using :poison_options is deprecated and might not work in future releases; use :json_options instead"
+    end
+
+    @tag capture_log: true
+    test "process_response_body parsed the body into an atom key map if configured" do
+      body = "{\"some\":\"json\"}"
+      Application.put_env(:elastix, :json_options, keys: :atoms)
+      assert HTTP.process_response_body(body) == %{some: "json"}
+      Application.delete_env(:elastix, :poison_options)
+    end
   end
 
   test "adding custom headers" do
@@ -70,6 +121,17 @@ defmodule Elastix.HTTPTest do
     assert {"Content-Type", "application/json; charset=UTF-8"} in fake_resp
   end
 
+  test "add_query_params/2" do
+    params = %{foo: "bar", biz: 1}
+    base = "http://localhost:9200/base"
+
+    assert HTTP.add_query_params(base, nil) == base
+    assert HTTP.add_query_params(base, %{}) == base
+    assert HTTP.add_query_params(base, []) == base
+    assert HTTP.add_query_params(base, foo: :bar, biz: 1) == "#{base}?foo=bar&biz=1"
+    assert HTTP.add_query_params(base, params) == "#{base}?biz=1&foo=bar"
+  end
+
   # Test implementation of custom headers
   def add_custom_headers(request, :foo) do
     [{"test", "pass"} | request.headers]
@@ -79,4 +141,5 @@ defmodule Elastix.HTTPTest do
   def return_headers(_, %HTTPoison.Request{headers: headers}, _, _, _, _) do
     headers
   end
+
 end

--- a/test/elastix/old/alias_test.exs
+++ b/test/elastix/old/alias_test.exs
@@ -1,4 +1,4 @@
-defmodule Elastix.AliasTest do
+defmodule Elastix.Old.AliasTest do
   use ExUnit.Case
   alias Elastix.Alias
   alias Elastix.Index
@@ -15,22 +15,22 @@ defmodule Elastix.AliasTest do
   test "aliases actions on existing index should respond with 200" do
     assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
 
-    {:ok, response} = Alias.post(@test_url, [
-      %{add: %{index: @test_index, alias: "alias1"}},
-      %{remove: %{index: @test_index, alias: "alias1"}}
-    ])
-    assert response.status_code == 200
+    assert {:ok, %{status_code: 200}} =
+             Alias.post(@test_url, [
+               %{add: %{index: @test_index, alias: "alias1"}},
+               %{remove: %{index: @test_index, alias: "alias1"}}
+             ])
   end
 
   test "remove unkown alias on existing index should respond with 404" do
     assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
 
-    {:ok, response} = Alias.post(@test_url, [%{remove: %{index: @test_index, alias: "alias1"}}])
-    assert response.status_code == 404
+    assert {:ok, %{status_code: 404}} =
+             Alias.post(@test_url, [%{remove: %{index: @test_index, alias: "alias1"}}])
   end
 
   test "alias actions on unknown index should respond with 404" do
-    {:ok, response} = Alias.post(@test_url, [%{add: %{index: @test_index, alias: "alias1"}}])
-    assert response.status_code == 404
+    assert {:ok, %{status_code: 404}} =
+             Alias.post(@test_url, [%{add: %{index: @test_index, alias: "alias1"}}])
   end
 end

--- a/test/elastix/old/bulk_test.exs
+++ b/test/elastix/old/bulk_test.exs
@@ -1,0 +1,207 @@
+defmodule Elastix.Old.BulkTest do
+  use ExUnit.Case
+  alias Elastix.Index
+  alias Elastix.Bulk
+  alias Elastix.Document
+  @old false
+
+  @test_url Elastix.config(:test_url)
+  @test_index Elastix.config(:test_index)
+
+  setup do
+    Index.delete(@test_url, @test_index)
+
+    :ok
+  end
+
+  test "make_path should make url from index name, type, and query params" do
+    if @old do
+    assert Bulk.make_path(@test_index, "tweet", version: 34, ttl: "1d") ==
+             "/#{@test_index}/tweet/_bulk?version=34&ttl=1d"
+    end
+  end
+
+  test "make_path should make url from index name and query params" do
+    if @old do
+    assert Bulk.make_path(@test_index, nil, version: 34, ttl: "1d") ==
+             "/#{@test_index}/_bulk?version=34&ttl=1d"
+    end
+  end
+
+  test "make_path should make url from query params" do
+    if @old do
+    assert Bulk.make_path(nil, nil, version: 34, ttl: "1d") == "/_bulk?version=34&ttl=1d"
+    end
+  end
+
+  test "bulk accepts httpoison options" do
+    lines = [
+        %{index: %{_id: "1"}},
+        %{field: "value1"},
+        %{index: %{_id: "2"}},
+        %{field: "value2"}
+      ]
+    {:error, %HTTPoison.Error{reason: :timeout}} =
+      Bulk.post @test_url, lines, index: @test_index, type: "message", httpoison_options: [recv_timeout: 0]
+  end
+
+  describe "test bulks with index and type in URL" do
+    setup do
+      {:ok,
+       lines: [
+         %{index: %{_id: "1"}},
+         %{field: "value1"},
+         %{index: %{_id: "2"}},
+         %{field: "value2"}
+       ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      {:ok, response} = Bulk.post(@test_url, lines, index: @test_index, type: "message")
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      {:ok, response} =
+        Bulk.post_raw(
+          @test_url,
+          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end),
+          index: @test_index,
+          type: "message"
+        )
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      {:ok, response} =
+        Bulk.post_to_iolist(@test_url, lines, index: @test_index, type: "message")
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+
+  describe "test bulks with index only in URL" do
+    setup do
+      {:ok,
+       lines: [
+         %{index: %{_id: "1", _type: "message"}},
+         %{field: "value1"},
+         %{index: %{_id: "2", _type: "message"}},
+         %{field: "value2"}
+       ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      {:ok, response} = Bulk.post(@test_url, lines, index: @test_index)
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      {:ok, response} =
+        Bulk.post_raw(
+          @test_url,
+          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end),
+          index: @test_index
+        )
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      {:ok, response} = Bulk.post_to_iolist(@test_url, lines, index: @test_index)
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+
+  describe "test bulks without index nor type in URL" do
+    setup do
+      {:ok,
+       lines: [
+         %{index: %{_id: "1", _type: "message", _index: @test_index}},
+         %{field: "value1"},
+         %{index: %{_id: "2", _type: "message", _index: @test_index}},
+         %{field: "value2"}
+       ]}
+    end
+
+    test "post bulk should execute it", %{lines: lines} do
+      {:ok, response} = Bulk.post(@test_url, lines)
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk with raw body should execute it", %{lines: lines} do
+      {:ok, response} =
+        Bulk.post_raw(
+          @test_url,
+          Enum.map(lines, fn line -> Poison.encode!(line) <> "\n" end)
+        )
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+
+    test "post bulk sending iolist should execute it", %{lines: lines} do
+      {:ok, response} = Bulk.post_to_iolist(@test_url, lines)
+
+      assert response.status_code == 200
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "1")
+
+      assert {:ok, %{status_code: 200}} =
+               Document.get(@test_url, @test_index, "message", "2")
+    end
+  end
+end

--- a/test/elastix/old/document_test.exs
+++ b/test/elastix/old/document_test.exs
@@ -1,0 +1,220 @@
+defmodule Elastix.Old.DocumentTest do
+  require Logger
+  use ExUnit.Case
+  alias Elastix.{Document, Index, Search}
+
+  @test_url Elastix.config(:test_url)
+  @test_index Elastix.config(:test_index)
+  @data %{
+    user: "örelbörel",
+    post_date: "2009-11-15T14:12:12",
+    message: "trying out Elasticsearch"
+  }
+  @old false
+
+  setup_all do
+    # Query the Elasticsearch instance to determine what version it is running
+    # so we can use it in tests.
+    {:ok, response} = Elastix.HTTP.get(@test_url)
+    {version, _rest} = Float.parse(response.body["version"]["number"])
+
+    {:ok, version: version}
+  end
+
+  setup do
+    Index.delete(@test_url, @test_index)
+
+    :ok
+  end
+
+  test "make_path should make url from index name, type, query params, id, and suffix" do
+    if @old do
+    assert Document.make_path(
+             @test_index,
+             "tweet",
+             [version: 34, ttl: "1d"],
+             2,
+             "_update"
+           ) == "/#{@test_index}/tweet/2/_update?version=34&ttl=1d"
+    end
+  end
+
+  test "make_path without and id should make url from index name, type, and query params" do
+    if @old do
+    assert Document.make_path(@test_index, "tweet", version: 34, ttl: "1d") ==
+             "/#{@test_index}/tweet?version=34&ttl=1d"
+    end
+  end
+
+  test "index should create and index with data", %{version: version} do
+    {:ok, response} = Document.index(@test_url, @test_index, "message", 1, @data)
+
+    assert response.status_code == 201
+    assert response.body["_id"] == "1"
+    assert response.body["_index"] == @test_index
+    assert response.body["_type"] == "message"
+    if version >= 6.0 do
+      assert response.body["result"] == "created"
+    else
+      assert response.body["created"] == true
+    end
+  end
+
+  test "index_new should index data without an id", %{version: version} do
+    {:ok, response} = Document.index_new(@test_url, @test_index, "message", @data)
+
+    assert response.status_code == 201
+    assert response.body["_id"]
+    assert response.body["_index"] == @test_index
+    assert response.body["_type"] == "message"
+    if version >= 6.0 do
+      assert response.body["result"] == "created"
+    else
+      assert response.body["created"] == true
+    end
+  end
+
+  test "get should return 404 if not index was created" do
+    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+
+    assert response.status_code == 404
+  end
+
+  test "get should return data with 200 after index" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+    body = response.body
+
+    assert response.status_code == 200
+    assert body["_source"]["user"] == "örelbörel"
+    assert body["_source"]["post_date"] == "2009-11-15T14:12:12"
+    assert body["_source"]["message"] == "trying out Elasticsearch"
+  end
+
+  test "delete should delete created index" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+
+    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+    assert response.status_code == 200
+
+    {:ok, response} = Document.delete(@test_url, @test_index, "message", 1)
+    assert response.status_code == 200
+
+    {:ok, response} = Document.get(@test_url, @test_index, "message", 1)
+    assert response.status_code == 404
+  end
+
+  test "delete by query should remove all docs that match" do
+    Document.index(@test_url, @test_index, "message", 1, @data, refresh: true)
+    Document.index(@test_url, @test_index, "message", 2, @data, refresh: true)
+
+    no_match = Map.put(@data, :user, "no match")
+    Document.index(@test_url, @test_index, "message", 3, no_match, refresh: true)
+
+    match_all_query = %{"query" => %{"match_all" => %{}}}
+
+    {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
+    assert response.status_code == 200
+    assert response.body["hits"]["total"] == 3
+
+    query = %{"query" => %{"match" => %{"user" => "örelbörel"}}}
+
+    {:ok, response} =
+      Document.delete_matching(@test_url, @test_index, query, refresh: true)
+
+    assert response.status_code == 200
+
+    {:ok, response} = Search.search(@test_url, @test_index, ["message"], match_all_query)
+    assert response.status_code == 200
+    assert response.body["hits"]["total"] == 1
+  end
+
+  test "update can partially update document" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+
+    new_post_date = "2017-03-17T14:12:12"
+    patch = %{doc: %{post_date: new_post_date}}
+
+    {:ok, response} = Document.update(@test_url, @test_index, "message", 1, patch)
+    assert response.status_code == 200
+
+    {:ok, %{body: body, status_code: status_code}} =
+      Document.get(@test_url, @test_index, "message", 1)
+
+    assert status_code == 200
+    assert body["_source"]["user"] == "örelbörel"
+    assert body["_source"]["post_date"] == new_post_date
+    assert body["_source"]["message"] == "trying out Elasticsearch"
+  end
+
+  test "can get multiple documents (multi get)" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+    Document.index(@test_url, @test_index, "message", 2, @data)
+
+    query = %{
+      "docs" => [
+        %{
+          "_index" => @test_index,
+          "_type" => "message",
+          "_id" => "1"
+        },
+        %{
+          "_index" => @test_index,
+          "_type" => "message",
+          "_id" => "2"
+        }
+      ]
+    }
+
+    {:ok, %{body: body, status_code: status_code}} = Document.mget(@test_url, query)
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
+
+  test "can get multiple documents (multi get with index)" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+    Document.index(@test_url, @test_index, "message", 2, @data)
+
+    query = %{
+      "docs" => [
+        %{
+          "_type" => "message",
+          "_id" => "1"
+        },
+        %{
+          "_type" => "message",
+          "_id" => "2"
+        }
+      ]
+    }
+
+    {:ok, %{body: body, status_code: status_code}} =
+      Document.mget(@test_url, query, @test_index)
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
+
+  test "can get multiple documents (multi get with index and type)" do
+    Document.index(@test_url, @test_index, "message", 1, @data)
+    Document.index(@test_url, @test_index, "message", 2, @data)
+
+    query = %{
+      "docs" => [
+        %{
+          "_id" => "1"
+        },
+        %{
+          "_id" => "2"
+        }
+      ]
+    }
+
+    {:ok, %{body: body, status_code: status_code}} =
+      Document.mget(@test_url, query, @test_index, "message")
+
+    assert status_code === 200
+    assert length(body["docs"]) == 2
+  end
+end

--- a/test/elastix/old/http_test.exs
+++ b/test/elastix/old/http_test.exs
@@ -1,0 +1,104 @@
+defmodule Elastix.Old.HTTPTest do
+  use ExUnit.Case
+  alias Elastix.HTTP
+  @old false
+
+  @test_url Elastix.config(:test_url)
+
+  setup_all do
+    # Query the Elasticsearch instance to determine what version it is running
+    # so we can use it in tests.
+    {:ok, response} = HTTP.get(@test_url)
+    {version, _rest} = Float.parse(response.body["version"]["number"])
+
+    {:ok, version: version}
+  end
+
+  test "prepare_url/2 should concat url with path" do
+    if @old do
+    assert HTTP.prepare_url("http://127.0.0.1:9200/", "/some_path") ==
+             "http://127.0.0.1:9200/some_path"
+    end
+  end
+
+  test "prepare_url/2 should concat url with a list of path parts" do
+    if @old do
+    assert HTTP.prepare_url("http://127.0.0.1:9200/", ["/some/", "/path/"]) ==
+             "http://127.0.0.1:9200/some/path"
+    end
+  end
+
+  test "get should respond with 200" do
+    {_, response} = HTTP.get(@test_url, [])
+    assert response.status_code == 200
+  end
+
+  test "post should respond with 400", %{version: version} do
+    {_, response} = HTTP.post(@test_url, [])
+    if version >= 6.0 do
+      assert response.status_code == 405
+    else
+      assert response.status_code == 400
+    end
+  end
+
+  test "put should respond with 400", %{version: version} do
+    {_, response} = HTTP.put(@test_url, [])
+    if version >= 6.0 do
+      assert response.status_code == 405
+    else
+      assert response.status_code == 400
+    end
+  end
+
+  test "delete should respond with 400" do
+    {_, response} = HTTP.delete(@test_url, [])
+    assert response.status_code == 400
+  end
+
+  test "process_response_body should parse the json body into a map" do
+    body = "{\"some\":\"json\"}"
+    assert HTTP.process_response_body(body) == %{"some" => "json"}
+  end
+
+  test "process_response_body returns the raw body if it cannot be parsed as json" do
+    body = "no_json"
+    assert HTTP.process_response_body(body) == body
+  end
+
+  test "process_response_body parsed the body into an atom key map if configured" do
+    body = "{\"some\":\"json\"}"
+    Application.put_env(:elastix, :poison_options, keys: :atoms)
+    assert HTTP.process_response_body(body) == %{some: "json"}
+    Application.delete_env(:elastix, :poison_options)
+  end
+
+  test "adding custom headers" do
+    Application.put_env(
+      :elastix,
+      :custom_headers,
+      {__MODULE__, :add_custom_headers, [:foo]}
+    )
+
+    Application.put_env(:elastix, :test_request_mfa, {__MODULE__, :return_headers, []})
+
+    fake_resp =
+      HTTP.request("GET", "#{@test_url}/_cluster/health", "", [{"yolo", "true"}])
+
+    Application.delete_env(:elastix, :test_request_mfa)
+    Application.delete_env(:elastix, :custom_headers)
+    assert {"yolo", "true"} in fake_resp
+    assert {"test", "pass"} in fake_resp
+    assert {"Content-Type", "application/json; charset=UTF-8"} in fake_resp
+  end
+
+  # Test implementation of custom headers
+  def add_custom_headers(request, :foo) do
+    [{"test", "pass"} | request.headers]
+  end
+
+  # Skip actual http request so we can test what we sent to poison.
+  def return_headers(_, %HTTPoison.Request{headers: headers}, _, _, _, _) do
+    headers
+  end
+end

--- a/test/elastix/old/index_test.exs
+++ b/test/elastix/old/index_test.exs
@@ -1,0 +1,67 @@
+defmodule Elastix.Old.IndexTest do
+  use ExUnit.Case
+  alias Elastix.Index
+
+  @test_url Elastix.config(:test_url)
+  @test_index Elastix.config(:test_index)
+
+  setup do
+    Index.delete(@test_url, @test_index)
+
+    :ok
+  end
+
+  test "exists? should return false if index is not created" do
+    assert {:ok, false} == Index.exists?(@test_url, @test_index)
+  end
+
+  test "exists? should return true if index is created" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, true} == Index.exists?(@test_url, @test_index)
+  end
+
+  test "create then delete should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.delete(@test_url, @test_index)
+  end
+
+  test "double create should respond with 400" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 400}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.delete(@test_url, @test_index)
+  end
+
+  test "get of uncreated index should respond with 404" do
+    assert {:ok, %{status_code: 404}} = Index.get(@test_url, @test_index)
+  end
+
+  test "get of created index should respond with 200 and index data" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+
+    {:ok, index} = Index.get(@test_url, @test_index)
+    assert index.status_code == 200
+
+    assert index.body[@test_index]
+  end
+
+  test "refresh of uncreated index should respond with 404" do
+    assert {:ok, %{status_code: 404}} = Index.refresh(@test_url, @test_index)
+  end
+
+  test "refresh of existing index should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+  end
+
+  test "open of existing index should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+    assert {:ok, %{status_code: 200}} = Index.open(@test_url, @test_index)
+  end
+
+  test "close of existing index should respond with 200" do
+    assert {:ok, %{status_code: 200}} = Index.create(@test_url, @test_index, %{})
+    assert {:ok, %{status_code: 200}} = Index.refresh(@test_url, @test_index)
+    assert {:ok, %{status_code: 200}} = Index.close(@test_url, @test_index)
+  end
+end

--- a/test/elastix/old/mapping_test.exs
+++ b/test/elastix/old/mapping_test.exs
@@ -1,9 +1,8 @@
-defmodule Elastix.MappingTest do
+defmodule Elastix.Old.MappingTest do
   use ExUnit.Case
   alias Elastix.Index
   alias Elastix.Mapping
   alias Elastix.Document
-  alias Elastix.HTTP
 
   @test_url Elastix.config(:test_url)
   @test_index Elastix.config(:test_index)
@@ -24,11 +23,12 @@ defmodule Elastix.MappingTest do
     user: 12,
     message: true
   }
+  @old false
 
   setup_all do
     # Query the Elasticsearch instance to determine what version it is running
     # so we can use it in tests.
-    {:ok, response} = HTTP.get(@test_url)
+    {:ok, response} = Elastix.HTTP.get(@test_url)
     version_string = response.body["version"]["number"]
     version = Elastix.version_to_tuple(version_string)
 
@@ -42,37 +42,32 @@ defmodule Elastix.MappingTest do
     :ok
   end
 
-  test "put_path/4 handles all combinations of params" do
-    # Old
-    assert Mapping.put_path("foo", "biz", %{}, []) == "/foo/_mapping/biz"
-    assert Mapping.put_path(["foo"], "biz", %{}, []) == "/foo/_mapping/biz"
-    assert Mapping.put_path(["foo", "bar"], "biz", %{}, []) == "/foo,bar/_mapping/biz"
-    assert Mapping.put_path(["foo", "bar"], "biz", %{}, version: 34, ttl: "1d") ==
-      "/foo,bar/_mapping/biz?version=34&ttl=1d"
+  defp elasticsearch_version do
+    %HTTPoison.Response{body: %{"version" => %{"number" => v}}, status_code: 200} =
+      Elastix.HTTP.get!(@test_url)
 
-    assert Mapping.put_path("foo", %{}, [], []) == "/foo/_mapping"
-    assert Mapping.put_path("foo", %{}, [version: 34, ttl: "1d"], []) ==
-      "/foo/_mapping?version=34&ttl=1d"
+    v |> String.split([".", "-"]) |> Enum.take(3) |> Enum.map(&String.to_integer/1)
+    |> List.to_tuple()
   end
 
-  test "get_path/3 handles all combinations of params" do
-    # Old
-    assert Mapping.get_path("foo", "biz", []) == "/foo/_mapping/biz"
-    assert Mapping.get_path(["foo"], "biz", []) == "/foo/_mapping/biz"
-    assert Mapping.get_path(["foo"], ["biz"], []) == "/foo/_mapping/biz"
-    assert Mapping.get_path("foo", ["biz"], []) == "/foo/_mapping/biz"
-    assert Mapping.get_path(["foo", "bar"], ["biz", "baz"], []) == "/foo,bar/_mapping/biz,baz"
-    assert Mapping.get_path(["foo", "bar"], ["biz", "baz"], version: 34, ttl: "1d") ==
-      "/foo,bar/_mapping/biz,baz?version=34&ttl=1d"
-
-    # New
-    assert Mapping.get_path("foo", [], []) == "/foo/_mapping"
-    assert Mapping.get_path("foo", [version: 34, ttl: "1d"], []) ==
-      "/foo/_mapping?version=34&ttl=1d"
+  test "make_path should make url from index names, types, and query params" do
+    if @old do
+    assert Mapping.make_path([@test_index], ["tweet"], version: 34, ttl: "1d") ==
+             "/#{@test_index}/_mapping/tweet?version=34&ttl=1d"
+    end
   end
 
-  test "make_all_path/2 makes url from types" do
-    assert Mapping.make_all_path(["tweet"]) == "/_mapping/tweet"
+  test "make_all_path should make url from types, and query params" do
+    if @old do
+    assert Mapping.make_all_path(["tweet"], version: 34, ttl: "1d") ==
+             "/_mapping/tweet?version=34&ttl=1d"
+    end
+  end
+
+  test "make_all_path should make url from query params" do
+    if @old do
+    assert Mapping.make_all_path(version: 34, ttl: "1d") == "/_mapping?version=34&ttl=1d"
+    end
   end
 
   test "put mapping with no index should error" do
@@ -95,24 +90,17 @@ defmodule Elastix.MappingTest do
     assert response.status_code == 404
   end
 
-  test "get with non existing mapping", %{version: version} do
+  test "get with non existing mapping" do
     Index.create(@test_url, @test_index, %{})
+    {:ok, response} = Mapping.get(@test_url, @test_index, "message")
 
-    cond do
-      version >= {6, 0, 0} ->
-        {:ok, response} = Mapping.get(@test_url, @test_index, include_type_name: false)
-        assert response.body == %{@test_index => %{"mappings" => %{}}}
-        assert response.status_code == 200
-      version >= {5, 5, 0} ->
-        {:ok, response} = Mapping.get(@test_url, @test_index, "message")
-        assert response.body["error"]["reason"] == "type[[message]] missing"
-        assert response.status_code == 404
-      true ->
-        {:ok, response} = Mapping.get(@test_url, @test_index, "message")
-        assert response.body == %{}
-        assert response.status_code == 404
+    if elasticsearch_version() >= {5, 5, 0} do
+      assert response.body["error"]["reason"] == "type[[message]] missing"
+    else
+      assert response.body == %{}
     end
 
+    assert response.status_code == 404
   end
 
   test "get mapping should return mapping" do

--- a/test/elastix/old/snapshot/repository_test.exs
+++ b/test/elastix/old/snapshot/repository_test.exs
@@ -1,0 +1,112 @@
+defmodule Elastix.Old.Snapshot.RepositoryTest do
+  @moduledoc """
+  Tests for the Elastix.Snapshot.Repository module functions.
+
+  Note that for these tests to run, Elasticsearch must be running and the
+  elasticsearch.yml file must have the following entry:
+
+    path.repo: /tmp
+  """
+
+  use ExUnit.Case
+  alias Elastix.Snapshot.Repository
+
+  @test_url Elastix.config(:test_url)
+  @test_repository_config %{"type" => "fs", "settings" => %{"location" => "/tmp/elastix/backups"}}
+
+  @old false
+
+  setup do
+    on_exit(fn ->
+      Repository.delete(@test_url, "elastix_test_repository_1")
+      Repository.delete(@test_url, "elastix_test_repository_2")
+    end)
+
+    :ok
+  end
+
+  describe "constructing paths" do
+    if @old do
+    test "make_path should make url from repository name and query params" do
+      assert Repository.make_path("elastix_test_unverified_backup", verify: false) ==
+               "/_snapshot/elastix_test_unverified_backup?verify=false"
+    end
+    end
+
+    test "make_path should make url from repository_name" do
+      assert Repository.make_path("elastix_test_repository_1") ==
+               "/_snapshot/elastix_test_repository_1"
+    end
+  end
+
+  describe "registering a repository" do
+    test "a repository" do
+      assert {:ok, %{status_code: 200}} =
+               Repository.register(
+                 @test_url,
+                 "elastix_test_repository_1",
+                 @test_repository_config
+               )
+    end
+
+    test "an unverified repository" do
+      assert {:ok, %{status_code: 200}} =
+               Repository.register(
+                 @test_url,
+                 "elastix_test_repository_1",
+                 @test_repository_config,
+                 verify: false
+               )
+    end
+  end
+
+  describe "verifying a repository" do
+    test "a registered but unverified repository is manually verified" do
+      Repository.register(
+        @test_url,
+        "elastix_test_repository_1",
+        @test_repository_config,
+        verify: false
+      )
+
+      assert {:ok, %{status_code: 200, body: %{"nodes" => _}}} =
+               Repository.verify(@test_url, "elastix_test_repository_1")
+    end
+  end
+
+  describe "retrieving information about a repository" do
+    test "repository doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Repository.get(@test_url, "nonexistent")
+    end
+
+    test "information about all repositories" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+      Repository.register(@test_url, "elastix_test_repository_2", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} = Repository.get(@test_url)
+    end
+
+    test "information about a specific repository" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} =
+               Repository.get(@test_url, "elastix_test_repository_1")
+    end
+  end
+
+  describe "deleting a repository" do
+    test "repository doesn't exist" do
+      assert {:ok, %{status_code: 404}} = Repository.delete(@test_url, "nonexistent")
+    end
+
+    test "references to the location where snapshots are stored are removed" do
+      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+
+      assert {:ok, %{status_code: 200}} =
+               Repository.delete(@test_url, "elastix_test_repository_1")
+
+      assert {:ok, %{status_code: 404}} =
+               Repository.get(@test_url, "elastix_test_repository_1")
+    end
+  end
+end

--- a/test/elastix/old/snapshot/snapshot_test.exs
+++ b/test/elastix/old/snapshot/snapshot_test.exs
@@ -1,0 +1,304 @@
+defmodule Elastix.Old.Snapshot.SnapshotTest do
+  @moduledoc """
+  Tests for the Elastix.Snapshot.Snapshot module functions.
+
+  Note that for these tests to run, Elasticsearch must be running and the
+  elasticsearch.yml file must have the following entry:
+
+    path.repo: /tmp
+
+  For testing purposes, snapshots are limited to test indices only.
+  """
+
+  use ExUnit.Case
+  use Retry
+  alias Elastix.Index
+  alias Elastix.Snapshot.{Repository, Snapshot}
+
+  @test_url Elastix.config(:test_url)
+  @test_repository "elastix_test_repository"
+  @old false
+
+  setup_all do
+    Index.create(@test_url, "elastix_test_index_1", %{})
+    Index.create(@test_url, "elastix_test_index_2", %{})
+    Index.create(@test_url, "elastix_test_index_3", %{})
+    Index.create(@test_url, "elastix_test_index_4", %{})
+    Index.create(@test_url, "elastix_test_index_5", %{})
+
+    Repository.register(@test_url, @test_repository, %{
+      type: "fs",
+      settings: %{location: "/tmp/elastix/backups"}
+    })
+
+    on_exit(fn ->
+      Index.delete(@test_url, "elastix_test_index_1")
+      Index.delete(@test_url, "elastix_test_index_2")
+      Index.delete(@test_url, "elastix_test_index_3")
+      Index.delete(@test_url, "elastix_test_index_4")
+      Index.delete(@test_url, "elastix_test_index_5")
+
+      Repository.delete(@test_url, @test_repository)
+    end)
+
+    :ok
+  end
+
+  setup do
+    on_exit(fn ->
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_1")
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_2")
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_3")
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_4")
+      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_5")
+    end)
+
+    :ok
+  end
+
+  describe "constructing paths" do
+    test "make_path should make url from repository name, snapshot name, and query params" do
+      if @old do
+      assert Snapshot.make_path(
+               @test_repository,
+               "elastix_test_snapshot_1",
+               wait_for_completion: true
+             ) ==
+               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1?wait_for_completion=true"
+      end
+    end
+
+    test "make_path should make url from repository name and snapshot name" do
+      if @old do
+      assert Snapshot.make_path(@test_repository, "elastix_test_snapshot_1") ==
+               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1"
+      end
+    end
+  end
+
+  describe "creating a snapshot" do
+    test "a snapshot of multiple indices in the cluster" do
+      Snapshot.create(
+        @test_url,
+        @test_repository,
+        "elastix_test_snapshot_2",
+        %{indices: "elastix_test_index_1,elastix_test_index_2"},
+        wait_for_completion: true
+      )
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{body: %{"snapshots" => snapshots}}} =
+            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_2")
+
+          snapshot = List.first(snapshots)
+          snapshot["state"] == "SUCCESS"
+        )
+
+        then
+
+        (
+          {:ok, %{body: %{"snapshots" => snapshots}}} =
+            Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_2")
+
+          snapshot = List.first(snapshots)
+          assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
+          assert Enum.member?(snapshot["indices"], "elastix_test_index_2")
+        )
+      end
+    end
+
+    test "a snapshot of a single index in the cluster" do
+      Snapshot.create(
+        @test_url,
+        @test_repository,
+        "elastix_test_snapshot_1",
+        %{indices: "elastix_test_index_1"},
+        wait_for_completion: true
+      )
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{body: %{"snapshots" => snapshots}}} =
+            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+          snapshot = List.first(snapshots)
+          snapshot["state"] == "SUCCESS"
+        )
+
+        then
+
+        (
+          {:ok, %{body: %{"snapshots" => snapshots}}} =
+            Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
+
+          snapshot = List.first(snapshots)
+          assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
+          refute Enum.member?(snapshot["indices"], "elastix_test_index_2")
+        )
+      end
+    end
+  end
+
+  describe "restoring a snapshot" do
+    test "all indices in a snapshot" do
+      Snapshot.create(
+        @test_url,
+        @test_repository,
+        "elastix_test_snapshot_4",
+        %{indices: "elastix_test_index_1,elastix_test_index_2"},
+        wait_for_completion: true
+      )
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{body: %{"snapshots" => snapshots}}} =
+            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_4")
+
+          snapshot = List.first(snapshots)
+          snapshot["state"] == "SUCCESS"
+        )
+
+        then
+
+        (
+          Index.close(@test_url, "elastix_test_index_1")
+          Index.close(@test_url, "elastix_test_index_2")
+          Index.delete(@test_url, "elastix_test_index_1")
+          Index.delete(@test_url, "elastix_test_index_2")
+        )
+      end
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_1")
+          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_2")
+        )
+
+        then
+
+        Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_4", %{
+          partial: true
+        })
+      end
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_1")
+        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_2")
+      end
+    end
+
+    test "a specific index in a snapshot" do
+      Snapshot.create(
+        @test_url,
+        @test_repository,
+        "elastix_test_snapshot_3",
+        %{indices: "elastix_test_index_3,elastix_test_index_4"},
+        wait_for_completion: true
+      )
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{status_code: 200, body: %{"snapshots" => snapshots}}} =
+            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_3")
+
+          snapshot = List.first(snapshots)
+          snapshot["state"] == "SUCCESS"
+        )
+
+        then
+
+        (
+          Index.close(@test_url, "elastix_test_index_3")
+          Index.close(@test_url, "elastix_test_index_4")
+          Index.delete(@test_url, "elastix_test_index_3")
+          Index.delete(@test_url, "elastix_test_index_4")
+        )
+      end
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_3")
+          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_4")
+        )
+
+        then
+
+        Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_3", %{
+          indices: "elastix_test_index_3"
+        })
+      end
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_3")
+        {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_4")
+      end
+    end
+  end
+
+  describe "retrieving status information for a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.status(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "information about all snapshots" do
+      assert {:ok, %{status_code: 200}} = Snapshot.status(@test_url)
+    end
+
+    test "information about all snapshots in a repository" do
+      assert {:ok, %{status_code: 200}} = Snapshot.status(@test_url, @test_repository)
+    end
+
+    test "information about a specific snapshot" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
+        indices: "elastix_test_index_5"
+      })
+
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        {:ok, %{status_code: 200}} =
+          Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_5")
+      end
+    end
+  end
+
+  describe "retrieving information about a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.get(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "information about all snapshots" do
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @test_repository)
+    end
+
+    test "information about a specific snapshot" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
+        indices: "elastix_test_index_5"
+      })
+
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_5")
+    end
+  end
+
+  describe "deleting a snapshot" do
+    test "snapshot doesn't exist" do
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.delete(@test_url, @test_repository, "nonexistent")
+    end
+
+    test "snapshot is deleted" do
+      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
+        indices: "elastix_test_index_5"
+      })
+
+      # This needs a wait to make sure that the restore completes before deleting
+      assert {:ok, %{status_code: 200}} =
+               Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_5")
+
+      assert {:ok, %{status_code: 404}} =
+               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_5")
+    end
+  end
+end

--- a/test/elastix/snapshot/repository_test.exs
+++ b/test/elastix/snapshot/repository_test.exs
@@ -3,90 +3,97 @@ defmodule Elastix.Snapshot.RepositoryTest do
   Tests for the Elastix.Snapshot.Repository module functions.
 
   Note that for these tests to run, Elasticsearch must be running and the
-  elasticsearch.yml file must have the following entry:
+  config file `elasticsearch.yml` file must have the following entry:
 
-    path.repo: /tmp
+  `path.repo: ["/tmp/elastix/backups"]`
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository)
   """
 
   use ExUnit.Case
   alias Elastix.Snapshot.Repository
+  alias Elastix.HTTP
 
   @test_url Elastix.config(:test_url)
-  @test_repository_config %{type: "fs", settings: %{location: "/tmp"}}
+  @repo_config %{"type" => "fs", "settings" => %{"location" => "/tmp/elastix/backups"}}
+  @repo_1 "elastix_test_repository_1"
+  @repo_2 "elastix_test_repository_2"
+
+  setup_all do
+    # Query the Elasticsearch instance to determine what version it is running
+    # so we can use it in tests.
+    {:ok, response} = HTTP.get(@test_url)
+    version_string = response.body["version"]["number"]
+    version = Elastix.version_to_tuple(version_string)
+
+    {:ok, version: version}
+  end
 
   setup do
     on_exit(fn ->
-      Repository.delete(@test_url, "elastix_test_repository_1")
-      Repository.delete(@test_url, "elastix_test_repository_2")
+      Repository.delete(@test_url, @repo_1)
+      Repository.delete(@test_url, @repo_2)
     end)
 
     :ok
   end
 
-  describe "constructing paths" do
-    test "make_path should make url from repository name and query params" do
-      assert Repository.make_path("elastix_test_unverified_backup", verify: false) ==
-               "/_snapshot/elastix_test_unverified_backup?verify=false"
-    end
-
-    test "make_path should make url from repository_name" do
-      assert Repository.make_path("elastix_test_repository_1") ==
-               "/_snapshot/elastix_test_repository_1"
+  describe "make_path/2" do
+    test "handles all parameter variations" do
+      assert Repository.make_path(nil) == "/_snapshot"
+      assert Repository.make_path("foo") == "/_snapshot/foo"
     end
   end
 
   describe "registering a repository" do
     test "a repository" do
-      assert {:ok, %{status_code: 200}} =
-               Repository.register(
-                 @test_url,
-                 "elastix_test_repository_1",
-                 @test_repository_config
-               )
-    end
-
-    test "an unverified repository" do
-      assert {:ok, %{status_code: 200}} =
-               Repository.register(
-                 @test_url,
-                 "elastix_test_repository_1",
-                 @test_repository_config,
-                 verify: false
-               )
+      {:ok, response} = Repository.register(@test_url, @repo_1, @repo_config)
+      assert response.status_code == 200
     end
   end
 
   describe "verifying a repository" do
     test "a registered but unverified repository is manually verified" do
-      Repository.register(
-        @test_url,
-        "elastix_test_repository_1",
-        @test_repository_config,
-        verify: false
-      )
+      {:ok, response} = Repository.register(@test_url, @repo_2, @repo_config, verify: false)
+      assert response.status_code == 200
 
-      assert {:ok, %{status_code: 200, body: %{"nodes" => _}}} =
-               Repository.verify(@test_url, "elastix_test_repository_1")
+      {:ok, response} = Repository.verify(@test_url, @repo_2)
+      assert response.status_code == 200
+      assert response.body["nodes"] != ""
     end
   end
 
   describe "retrieving information about a repository" do
     test "repository doesn't exist" do
-      assert {:ok, %{status_code: 404}} = Repository.get(@test_url, "nonexistent")
+      {:ok, response} = Repository.get(@test_url, "nonexistent")
+      assert response.status_code == 404
     end
 
     test "information about all repositories" do
-      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
-      Repository.register(@test_url, "elastix_test_repository_2", @test_repository_config)
+      {:ok, %{status_code: 200}} = Repository.register(@test_url, @repo_1, @repo_config)
+      {:ok, %{status_code: 200}} = Repository.register(@test_url, @repo_2, @repo_config)
 
-      assert {:ok, %{status_code: 200}} = Repository.get(@test_url)
+      {:ok, response} = Repository.get(@test_url)
+      assert response.status_code == 200
+      assert response.body[@repo_1] == @repo_config
+      assert response.body[@repo_2] == @repo_config
     end
 
     test "information about a specific repository" do
-      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+      Repository.register(@test_url, @repo_1, @repo_config)
+      {:ok, response} = Repository.get(@test_url, @repo_1)
+      assert response.status_code == 200
+      assert response.body[@repo_1] == @repo_config
+    end
+  end
 
-      assert {:ok, %{status_code: 200}} =
-               Repository.get(@test_url, "elastix_test_repository_1")
+  describe "cleanup" do
+    test "repository", %{version: version} do
+      if version >= {7, 0, 0} do
+        {:ok, %{status_code: 200}} = Repository.register(@test_url, @repo_1, @repo_config)
+        {:ok, response} = Repository.cleanup(@test_url, @repo_1)
+        assert response.status_code == 200
+      end
     end
   end
 
@@ -96,13 +103,10 @@ defmodule Elastix.Snapshot.RepositoryTest do
     end
 
     test "references to the location where snapshots are stored are removed" do
-      Repository.register(@test_url, "elastix_test_repository_1", @test_repository_config)
+      assert {:ok, %{status_code: 200}} = Repository.register(@test_url, @repo_1, @repo_config)
 
-      assert {:ok, %{status_code: 200}} =
-               Repository.delete(@test_url, "elastix_test_repository_1")
-
-      assert {:ok, %{status_code: 404}} =
-               Repository.get(@test_url, "elastix_test_repository_1")
+      assert {:ok, %{status_code: 200}} = Repository.delete(@test_url, @repo_1)
+      assert {:ok, %{status_code: 404}} = Repository.get(@test_url, @repo_1)
     end
   end
 end

--- a/test/elastix/snapshot/snapshot_test.exs
+++ b/test/elastix/snapshot/snapshot_test.exs
@@ -3,9 +3,11 @@ defmodule Elastix.Snapshot.SnapshotTest do
   Tests for the Elastix.Snapshot.Snapshot module functions.
 
   Note that for these tests to run, Elasticsearch must be running and the
-  elasticsearch.yml file must have the following entry:
+  config file `elasticsearch.yml` file must have the following entry:
 
-    path.repo: /tmp
+  `path.repo: ["/tmp/elastix/backups"]`
+
+  [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository)
 
   For testing purposes, snapshots are limited to test indices only.
   """
@@ -16,28 +18,37 @@ defmodule Elastix.Snapshot.SnapshotTest do
   alias Elastix.Snapshot.{Repository, Snapshot}
 
   @test_url Elastix.config(:test_url)
-  @test_repository "elastix_test_repository"
+  @repo "elastix_test_repository"
+  @repo_config %{type: "fs", settings: %{location: "/tmp/elastix/backups"}}
+  @index_1 "elastix_test_index_1"
+  @index_2 "elastix_test_index_2"
+  @index_3 "elastix_test_index_3"
+  @index_4 "elastix_test_index_4"
+  @index_5 "elastix_test_index_5"
+
+  @snapshot_1 "elastix_test_snapshot_1"
+  @snapshot_2 "elastix_test_snapshot_2"
+  @snapshot_3 "elastix_test_snapshot_3"
+  @snapshot_4 "elastix_test_snapshot_4"
+  @snapshot_5 "elastix_test_snapshot_5"
 
   setup_all do
-    Index.create(@test_url, "elastix_test_index_1", %{})
-    Index.create(@test_url, "elastix_test_index_2", %{})
-    Index.create(@test_url, "elastix_test_index_3", %{})
-    Index.create(@test_url, "elastix_test_index_4", %{})
-    Index.create(@test_url, "elastix_test_index_5", %{})
+    Index.create(@test_url, @index_1, %{})
+    Index.create(@test_url, @index_2, %{})
+    Index.create(@test_url, @index_3, %{})
+    Index.create(@test_url, @index_4, %{})
+    Index.create(@test_url, @index_5, %{})
 
-    Repository.register(@test_url, @test_repository, %{
-      type: "fs",
-      settings: %{location: "/tmp"}
-    })
+    Repository.register(@test_url, @repo, @repo_config)
 
     on_exit(fn ->
-      Index.delete(@test_url, "elastix_test_index_1")
-      Index.delete(@test_url, "elastix_test_index_2")
-      Index.delete(@test_url, "elastix_test_index_3")
-      Index.delete(@test_url, "elastix_test_index_4")
-      Index.delete(@test_url, "elastix_test_index_5")
+      Index.delete(@test_url, @index_1)
+      Index.delete(@test_url, @index_2)
+      Index.delete(@test_url, @index_3)
+      Index.delete(@test_url, @index_4)
+      Index.delete(@test_url, @index_5)
 
-      Repository.delete(@test_url, @test_repository)
+      Repository.delete(@test_url, @repo)
     end)
 
     :ok
@@ -45,91 +56,65 @@ defmodule Elastix.Snapshot.SnapshotTest do
 
   setup do
     on_exit(fn ->
-      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_1")
-      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_2")
-      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_3")
-      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_4")
-      Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_5")
+      Snapshot.delete(@test_url, @repo, @snapshot_1)
+      Snapshot.delete(@test_url, @repo, @snapshot_2)
+      Snapshot.delete(@test_url, @repo, @snapshot_3)
+      Snapshot.delete(@test_url, @repo, @snapshot_4)
+      Snapshot.delete(@test_url, @repo, @snapshot_5)
     end)
 
     :ok
   end
 
   describe "constructing paths" do
-    test "make_path should make url from repository name, snapshot name, and query params" do
-      assert Snapshot.make_path(
-               @test_repository,
-               "elastix_test_snapshot_1",
-               wait_for_completion: true
-             ) ==
-               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1?wait_for_completion=true"
-    end
-
-    test "make_path should make url from repository name and snapshot name" do
-      assert Snapshot.make_path(@test_repository, "elastix_test_snapshot_1") ==
-               "/_snapshot/#{@test_repository}/elastix_test_snapshot_1"
+    test "make_path/2 makes path from repository name and snapshot name" do
+      assert Snapshot.make_path(@repo, @snapshot_1) == "/_snapshot/#{@repo}/#{@snapshot_1}"
     end
   end
 
   describe "creating a snapshot" do
     test "a snapshot of multiple indices in the cluster" do
-      Snapshot.create(
-        @test_url,
-        @test_repository,
-        "elastix_test_snapshot_2",
-        %{indices: "elastix_test_index_1,elastix_test_index_2"},
-        wait_for_completion: true
-      )
+      {:ok, response} = Snapshot.create(@test_url, @repo, @snapshot_2,
+        %{indices: "#{@index_1},#{@index_2}"}, wait_for_completion: true)
+      assert response.status_code == 200
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{body: %{"snapshots" => snapshots}}} =
-            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_2")
-
-          snapshot = List.first(snapshots)
+          {:ok, response} = Snapshot.status(@test_url, @repo, @snapshot_2)
+          snapshot = List.first(response.body["snapshots"])
           snapshot["state"] == "SUCCESS"
         )
 
         then
 
         (
-          {:ok, %{body: %{"snapshots" => snapshots}}} =
-            Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_2")
-
-          snapshot = List.first(snapshots)
-          assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
-          assert Enum.member?(snapshot["indices"], "elastix_test_index_2")
+          {:ok, response} = Snapshot.get(@test_url, @repo, @snapshot_2)
+          snapshot = List.first(response.body["snapshots"])
+          assert Enum.member?(snapshot["indices"], @index_1)
+          assert Enum.member?(snapshot["indices"], @index_2)
         )
       end
     end
 
     test "a snapshot of a single index in the cluster" do
-      Snapshot.create(
-        @test_url,
-        @test_repository,
-        "elastix_test_snapshot_1",
-        %{indices: "elastix_test_index_1"},
-        wait_for_completion: true
-      )
+      {:ok, response} = Snapshot.create(@test_url, @repo, @snapshot_1,
+        %{indices: @index_1}, wait_for_completion: true)
+      assert response.status_code == 200
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{body: %{"snapshots" => snapshots}}} =
-            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_1")
-
-          snapshot = List.first(snapshots)
+          {:ok, response} = Snapshot.status(@test_url, @repo, @snapshot_1)
+          snapshot = List.first(response.body["snapshots"])
           snapshot["state"] == "SUCCESS"
         )
 
         then
 
         (
-          {:ok, %{body: %{"snapshots" => snapshots}}} =
-            Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_1")
-
-          snapshot = List.first(snapshots)
-          assert Enum.member?(snapshot["indices"], "elastix_test_index_1")
-          refute Enum.member?(snapshot["indices"], "elastix_test_index_2")
+          {:ok, response} = Snapshot.get(@test_url, @repo, @snapshot_1)
+          snapshot = List.first(response.body["snapshots"])
+          assert Enum.member?(snapshot["indices"], @index_1)
+          refute Enum.member?(snapshot["indices"], @index_2)
         )
       end
     end
@@ -137,65 +122,54 @@ defmodule Elastix.Snapshot.SnapshotTest do
 
   describe "restoring a snapshot" do
     test "all indices in a snapshot" do
-      Snapshot.create(
-        @test_url,
-        @test_repository,
-        "elastix_test_snapshot_4",
-        %{indices: "elastix_test_index_1,elastix_test_index_2"},
-        wait_for_completion: true
-      )
+      {:ok, response} = Snapshot.create(@test_url, @repo, @snapshot_4,
+        %{indices: "#{@index_1},#{@index_2}"}, wait_for_completion: true)
+      assert response.status_code == 200
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{body: %{"snapshots" => snapshots}}} =
-            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_4")
-
-          snapshot = List.first(snapshots)
+          {:ok, response} = Snapshot.status(@test_url, @repo, @snapshot_4)
+          snapshot = List.first(response.body["snapshots"])
           snapshot["state"] == "SUCCESS"
         )
 
         then
 
         (
-          Index.close(@test_url, "elastix_test_index_1")
-          Index.close(@test_url, "elastix_test_index_2")
-          Index.delete(@test_url, "elastix_test_index_1")
-          Index.delete(@test_url, "elastix_test_index_2")
+          Index.close(@test_url, @index_1)
+          Index.close(@test_url, @index_2)
+          Index.delete(@test_url, @index_1)
+          Index.delete(@test_url, @index_2)
         )
       end
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_1")
-          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_2")
+          {:ok, %{status_code: 404}} = Index.get(@test_url, @index_1)
+          {:ok, %{status_code: 404}} = Index.get(@test_url, @index_2)
         )
 
         then
 
-        Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_4", %{
-          partial: true
-        })
+        Snapshot.restore(@test_url, @repo, @snapshot_4, %{partial: true})
       end
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
-        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_1")
-        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_2")
+        {:ok, %{status_code: 200}} = Index.get(@test_url, @index_1)
+        {:ok, %{status_code: 200}} = Index.get(@test_url, @index_2)
       end
     end
 
     test "a specific index in a snapshot" do
-      Snapshot.create(
-        @test_url,
-        @test_repository,
-        "elastix_test_snapshot_3",
-        %{indices: "elastix_test_index_3,elastix_test_index_4"},
-        wait_for_completion: true
-      )
+      {:ok, response} = Snapshot.create(@test_url, @repo, @snapshot_3,
+        %{indices: Enum.join([@index_3, @index_4], ",")}, wait_for_completion: true)
+      assert response.status_code == 200
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{status_code: 200, body: %{"snapshots" => snapshots}}} =
-            Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_3")
+          {:ok, response} = Snapshot.status(@test_url, @repo, @snapshot_3)
+          assert response.status_code == 200
+          snapshots = response.body["snapshots"]
 
           snapshot = List.first(snapshots)
           snapshot["state"] == "SUCCESS"
@@ -204,37 +178,34 @@ defmodule Elastix.Snapshot.SnapshotTest do
         then
 
         (
-          Index.close(@test_url, "elastix_test_index_3")
-          Index.close(@test_url, "elastix_test_index_4")
-          Index.delete(@test_url, "elastix_test_index_3")
-          Index.delete(@test_url, "elastix_test_index_4")
+          Index.close(@test_url, @index_3)
+          Index.close(@test_url, @index_4)
+          Index.delete(@test_url, @index_3)
+          Index.delete(@test_url, @index_4)
         )
       end
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
         (
-          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_3")
-          {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_4")
+          {:ok, %{status_code: 404}} = Index.get(@test_url, @index_3)
+          {:ok, %{status_code: 404}} = Index.get(@test_url, @index_4)
         )
 
         then
 
-        Snapshot.restore(@test_url, @test_repository, "elastix_test_snapshot_3", %{
-          indices: "elastix_test_index_3"
-        })
+        Snapshot.restore(@test_url, @repo, @snapshot_3, %{indices: @index_3})
       end
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
-        {:ok, %{status_code: 200}} = Index.get(@test_url, "elastix_test_index_3")
-        {:ok, %{status_code: 404}} = Index.get(@test_url, "elastix_test_index_4")
+        {:ok, %{status_code: 200}} = Index.get(@test_url, @index_3)
+        {:ok, %{status_code: 404}} = Index.get(@test_url, @index_4)
       end
     end
   end
 
   describe "retrieving status information for a snapshot" do
     test "snapshot doesn't exist" do
-      assert {:ok, %{status_code: 404}} =
-               Snapshot.status(@test_url, @test_repository, "nonexistent")
+      assert {:ok, %{status_code: 404}} = Snapshot.status(@test_url, @repo, "nonexistent")
     end
 
     test "information about all snapshots" do
@@ -242,57 +213,55 @@ defmodule Elastix.Snapshot.SnapshotTest do
     end
 
     test "information about all snapshots in a repository" do
-      assert {:ok, %{status_code: 200}} = Snapshot.status(@test_url, @test_repository)
+      assert {:ok, %{status_code: 200}} = Snapshot.status(@test_url, @repo)
     end
 
     test "information about a specific snapshot" do
-      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
-        indices: "elastix_test_index_5"
-      })
+      Snapshot.create(@test_url, @repo, @snapshot_5, %{indices: @index_5})
 
       wait lin_backoff(500, 1) |> expiry(5_000) do
-        {:ok, %{status_code: 200}} =
-          Snapshot.status(@test_url, @test_repository, "elastix_test_snapshot_5")
+        {:ok, %{status_code: 200}} = Snapshot.status(@test_url, @repo, @snapshot_5)
       end
     end
   end
 
   describe "retrieving information about a snapshot" do
     test "snapshot doesn't exist" do
-      assert {:ok, %{status_code: 404}} =
-               Snapshot.get(@test_url, @test_repository, "nonexistent")
+      assert {:ok, %{status_code: 404}} = Snapshot.get(@test_url, @repo, "nonexistent")
     end
 
     test "information about all snapshots" do
-      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @test_repository)
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @repo)
     end
 
     test "information about a specific snapshot" do
-      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
-        indices: "elastix_test_index_5"
-      })
-
-      assert {:ok, %{status_code: 200}} =
-               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_5")
+      Snapshot.create(@test_url, @repo, @snapshot_5, %{indices: @index_5})
+      assert {:ok, %{status_code: 200}} = Snapshot.get(@test_url, @repo, @snapshot_5)
     end
   end
 
   describe "deleting a snapshot" do
     test "snapshot doesn't exist" do
-      assert {:ok, %{status_code: 404}} =
-               Snapshot.delete(@test_url, @test_repository, "nonexistent")
+      assert {:ok, %{status_code: 404}} = Snapshot.delete(@test_url, @repo, "nonexistent")
     end
 
     test "snapshot is deleted" do
-      Snapshot.create(@test_url, @test_repository, "elastix_test_snapshot_5", %{
-        indices: "elastix_test_index_5"
-      })
+      Snapshot.create(@test_url, @repo, @snapshot_5, %{indices: @index_5})
 
-      assert {:ok, %{status_code: 200}} =
-               Snapshot.delete(@test_url, @test_repository, "elastix_test_snapshot_5")
+      wait lin_backoff(500, 1) |> expiry(5_000) do
+        (
+          {:ok, response} = Snapshot.status(@test_url, @repo, @snapshot_5)
+          snapshot = List.first(response.body["snapshots"])
+          snapshot["state"] == "SUCCESS"
+        )
 
-      assert {:ok, %{status_code: 404}} =
-               Snapshot.get(@test_url, @test_repository, "elastix_test_snapshot_5")
+        then
+
+        (
+          assert {:ok, %{status_code: 200}} = Snapshot.delete(@test_url, @repo, @snapshot_5)
+          assert {:ok, %{status_code: 404}} = Snapshot.get(@test_url, @repo, @snapshot_5)
+        )
+      end
     end
   end
 end

--- a/test/elastix/template_test.exs
+++ b/test/elastix/template_test.exs
@@ -1,0 +1,96 @@
+defmodule Elastix.TemplateTest do
+
+  use ExUnit.Case
+
+  alias Elastix.Template
+
+  # @test_url Elastix.config(:test_url)
+
+  @test_url Elastix.config(:test_url)
+  @template "elastix_test"
+
+  setup do
+    on_exit(fn ->
+      Template.delete(@test_url, @template)
+    end)
+
+    template = """
+    {
+      "template" : "logstash-*",
+      "version" : 60001,
+      "settings" : {
+        "index.refresh_interval" : "5s"
+      },
+      "mappings" : {
+        "_default_" : {
+          "dynamic_templates" : [ {
+            "message_field" : {
+              "path_match" : "message",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text",
+                "norms" : false
+              }
+            }
+          }, {
+            "string_fields" : {
+              "match" : "*",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text", "norms" : false,
+                "fields" : {
+                  "keyword" : { "type": "keyword", "ignore_above": 256 }
+                }
+              }
+            }
+          } ],
+          "properties" : {
+            "@timestamp": { "type": "date"},
+            "@version": { "type": "keyword"},
+            "geoip"  : {
+              "dynamic": true,
+              "properties" : {
+                "ip": { "type": "ip" },
+                "location" : { "type" : "geo_point" },
+                "latitude" : { "type" : "half_float" },
+                "longitude" : { "type" : "half_float" }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    {:ok, template_data: template}
+  end
+
+  test "make_path/1 makes path from params" do
+    assert Template.make_path("foo") == "/_template/foo"
+  end
+
+  test "creates template", %{template_data: template_data} do
+    {:ok, response} = Template.put(@test_url, @template, template_data)
+    assert response.status_code == 200
+  end
+
+  test "gets template info", %{template_data: template_data} do
+    {:ok, response} = Template.put(@test_url, @template, template_data)
+    assert response.status_code == 200
+
+    {:ok, response} = Template.get(@test_url, @template)
+    assert response.status_code == 200
+    assert response.body[@template]["index_patterns"] == ["logstash-*"]
+  end
+
+  test "checks if template exists", %{template_data: template_data} do
+    assert {:ok, false} == Template.exists?(@test_url, @template)
+
+    {:ok, response} = Template.put(@test_url, @template, template_data)
+    assert response.status_code == 200
+
+    assert {:ok, true} == Template.exists?(@test_url, @template)
+  end
+
+end
+

--- a/test/elastix_test.exs
+++ b/test/elastix_test.exs
@@ -1,3 +1,10 @@
 defmodule ElastixTest do
   use ExUnit.Case
+
+  test "version_to_tuple/1" do
+    assert Elastix.version_to_tuple("1.0") == {1, 0, 0}
+    assert Elastix.version_to_tuple("1.1") == {1, 1, 0}
+    assert Elastix.version_to_tuple("1.2.3") == {1, 2, 3}
+  end
+
 end


### PR DESCRIPTION
Elasticsearch 7.0 removes types from indexes, which has some incompatible changes to the APIs. This PR adds support while keeping compatibility. Mostly this works fine, except that I could not figure out a way to avoid the obsolete types list in Elastix.Search.search.

Add support for managing templates in a new Elastix.Templates module.

Make Elastix.Bulk.post_raw/4 accept builk data in iodata format, allowing encoding errors to be handled before calling the API.

Use Logger instead of IO to print deprecation warnings, making it easier to log messages tests.

Make general code changes:

* Use the same functions to handle arguments in all modules
* Use basic types for specs to make them shorter and easier to read
* Avoid piping when it is clearer
* Use use access protocol for keyword access instead of Keyword.get
* Use shorter names for vars to avoid breaking lines
* Use head matching style instead of if/else

Add more documentation and examples for functions. The home page is still using the old pre-7.x API. At some point the new API should be the default.

Make improvements to tests:

* Adding Dializer and fixing issues
* Making lines shorter by using variables and splitting requests from asserts
* Fixes a problem in snapshot where it would try to delete a snapshot before processing had completed
* Use the Elasticsearch version to customize tests
* Added old tests in test/elastix/old with just the minimum changes required to make them pass with the new code

It has mainly been tested with Elasticsearch 6.8 and 7.4.