### PR TITLE
Update versions in travis config and mix.exs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 dist: trusty
 language: elixir
 elixir:
-  - 1.3.3
-  - 1.4.5
-  - 1.5.3
   - 1.6.1
+  - 1.7.4
+  - 1.8.2
+  - 1.9.4
 services:
   - elasticsearch
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.0
+
+### Breaking changes
+
+ - Drop support for Elixir <1.6
+
 ## 0.7.1
 
 ### Package improvements

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Elastix.Mixfile do
     [
       app: :elastix,
       version: @version,
-      elixir: "~> 1.0",
+      elixir: "~> 1.6",
       description: "A DSL-free Elastic / Elasticsearch client for Elixir.",
       package: package(),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
The version of poison we are using doesn't support Elixir <1.6, and I don't think there's any good reason to support it either, so this updates the Elixir versions in the tests and the minimum version in `mix.exs`.