### PR TITLE
Add get method to alias module

### DIFF
--- a/lib/elastix/alias.ex
+++ b/lib/elastix/alias.ex
@@ -20,4 +20,17 @@ defmodule Elastix.Alias do
     prepare_url(elastic_url, ["_aliases"])
     |> HTTP.post(JSON.encode!(%{actions: actions}))
   end
+
+  @doc """
+  Returns information about one or more index aliases.
+
+  ## Examples
+      iex> Elastix.Alias.get("http://localhost:9200", "alias1")
+      {:ok, %HTTPoison.Response{...}}
+  """
+  @spec get(elastic_url :: String.t(), name :: String.t()) :: HTTP.resp()
+  def get(elastic_url, name \\ "") do
+    prepare_url(elastic_url, ["_alias", name])
+    |> HTTP.get()
+  end
 end

--- a/test/elastix/alias_test.exs
+++ b/test/elastix/alias_test.exs
@@ -9,6 +9,8 @@ defmodule Elastix.AliasTest do
   setup do
     Index.delete(@test_url, @test_index)
 
+    Alias.post(@test_url, [%{remove: %{index: @test_index, alias: "alias1"}}])
+
     :ok
   end
 
@@ -32,5 +34,45 @@ defmodule Elastix.AliasTest do
   test "alias actions on unknown index should respond with 404" do
     assert {:ok, %{status_code: 404}} =
              Alias.post(@test_url, [%{add: %{index: @test_index, alias: "alias1"}}])
+  end
+
+  test "get all alias should respond with 200" do
+    assert {:ok, %{status_code: _}} = Index.create(@test_url, @test_index, %{})
+
+    assert {:ok, %{status_code: 200}} =
+             Alias.post(@test_url, [
+               %{add: %{index: @test_index, alias: "alias1"}}
+             ])
+
+    assert {:ok,
+            %{
+              status_code: 200,
+              body: %{@test_index => %{"aliases" => %{"alias1" => %{}}}}
+            }} = Alias.get(@test_url)
+  end
+
+  test "get alias on existing alias should respond with 200" do
+    assert {:ok, %{status_code: _}} = Index.create(@test_url, @test_index, %{})
+
+    assert {:ok, %{status_code: 200}} =
+             Alias.post(@test_url, [
+               %{add: %{index: @test_index, alias: "alias1"}}
+             ])
+
+    assert {:ok,
+            %{
+              status_code: 200,
+              body: %{@test_index => %{"aliases" => %{"alias1" => %{}}}}
+            }} = Alias.get(@test_url, "alias1")
+  end
+
+  test "get alias on unknown alias should respond with 404" do
+    assert {:ok, %{status_code: _}} = Index.create(@test_url, @test_index, %{})
+
+    assert {:ok,
+            %{
+              status_code: 404,
+              body: %{"error" => "alias [unknown_alias] missing", "status" => 404}
+            }} = Alias.get(@test_url, "unknown_alias")
   end
 end


### PR DESCRIPTION
Add support to the [Get index alias API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-alias.html).

