### PR TITLE
Index.exists? returns false on any other than 200 code

### DIFF
--- a/lib/elastix/index.ex
+++ b/lib/elastix/index.ex
@@ -68,7 +68,7 @@ defmodule Elastix.Index do
       {:ok, response} ->
         case response.status_code do
           200 -> {:ok, true}
-          404 -> {:ok, false}
+          _ -> {:ok, false}
         end
 
       err ->


### PR DESCRIPTION
On production elasticsearch is behind a proxy and when process is
down the status code is 502, this result of this stacktrace:

```
"** (CaseClauseError) no case clause matching: 502\n    (elastix 0.7.1) lib/elastix/index.ex:68: Elastix.Index.exists?/2\n    (minimal_server 0.1.0) lib/minimal_server/tests.ex:111: MinimalServer.Tests.elasticsearch_test/0\n    (minimal_server 0.1.0) lib/minimal_server/router.ex:27: MinimalServer.Router.message/0\n    (minimal_server 0.1.0) lib/minimal_server/router.ex:11: anonymous fn/1 in MinimalServer.Router.do_match/4\n    (minimal_server 0.1.0) lib/minimal_server/router.ex:1: MinimalServer.Router.plug_builder_call/2\n    (minimal_server 0.1.0) lib/plug/error_handler.ex:64: MinimalServer.Router.call/2\n    (plug 1.6.3) lib/plug/router/utils.ex:92: Plug.Router.Utils.forward/4\n    (minimal_server 0.1.0) lib/minimal_server/endpoint.ex:1: MinimalServer.Endpoint.plug_builder_call/2\n"
```